### PR TITLE
Improve errors and output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to disable Black formatter, you can [disable this extension](https:/
 | black-formatter.args  | `[]`    | Custom arguments passed to `black`. E.g `"black-formatter.args" = ["--config", "<file>"]`                                                                                                                                                                                |
 | black-formatter.trace | `error` | Sets the tracing level for the extension.                                                                                                                                                                                                                                |
 | black-formatter.path  | `[]`    | Setting to provide custom `black` executable. This will slow down formatting, since we will have to run `black` executable every time or file save or open. Example 1: `["~/global_env/black"]` Example 2: `["conda", "run", "-n", "lint_env", "python", "-m", "black"]` |
-| black-formatter.show-formatting-messages | `true` | Whether to show messages in UI when extension didn't format file for any reason.
+| black-formatter.showNotification | `on-warn` | When extension is allowed to show messages in UI: `on-message`, `on-warn`, `on-error`, `on-crash`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If you want to disable Black formatter, you can [disable this extension](https:/
 | black-formatter.args  | `[]`    | Custom arguments passed to `black`. E.g `"black-formatter.args" = ["--config", "<file>"]`                                                                                                                                                                                |
 | black-formatter.trace | `error` | Sets the tracing level for the extension.                                                                                                                                                                                                                                |
 | black-formatter.path  | `[]`    | Setting to provide custom `black` executable. This will slow down formatting, since we will have to run `black` executable every time or file save or open. Example 1: `["~/global_env/black"]` Example 2: `["conda", "run", "-n", "lint_env", "python", "-m", "black"]` |
+| black-formatter.show-formatting-messages | `true` | Whether to show messages in UI when extension didn't format file for any reason.
 
 ## Commands
 

--- a/bundled/formatter/format_server.py
+++ b/bundled/formatter/format_server.py
@@ -131,20 +131,25 @@ def _get_error_message_from_stderr(stderr: str) -> str:
     first_line_priority = 1
 
     for line in map(str.strip, stderr.splitlines()):
-        if line.lower().startswith('error:'):
+        if line.lower().startswith("error:"):
             error, *parse_error = line.lower().split("cannot parse:")
             if parse_error:
                 # the most relevant thing here is the line that couldn't be parsed, so show it first
-                filename = error.replace("error:", "").replace("cannot format", "").strip()
+                filename = (
+                    error.replace("error:", "").replace("cannot format", "").strip()
+                )
                 message.append(
-                    (first_line_priority, f"Error: {parse_error[0]} cannot be parsed in {filename}")
+                    (
+                        first_line_priority,
+                        f"Error: {parse_error[0]} cannot be parsed in {filename}",
                     )
+                )
             else:
                 message.append((first_line_priority, line))
         else:
             message.append((current_priority, line))
             current_priority -= 1
-    
+
     return "  ".join(line for _, line in sorted(message, reverse=True))
 
 
@@ -202,7 +207,9 @@ def _format(
             )
     except Exception as e:
         # this is quite unexpected and we should never end up here
-        error_text = f"Encountered exception while executing black:\r\n{traceback.format_exc()}"
+        error_text = (
+            f"Encountered exception while executing black:\r\n{traceback.format_exc()}"
+        )
         LSP_SERVER.show_message_log(error_text, msg_type=types.MessageType.Error)
         LSP_SERVER.show_message(
             f"Fatal error: {e!r}, please see Output > Black Formatter for more info",
@@ -213,9 +220,11 @@ def _format(
     if result.stderr:
         LSP_SERVER.show_message_log(result.stderr, msg_type=types.MessageType.Error)
         if "error:" in result.stderr.lower() and settings["show-formatting-messages"]:
-            LSP_SERVER.show_message(_get_error_message_from_stderr(result.stderr), msg_type=types.MessageType.Error)
+            LSP_SERVER.show_message(
+                _get_error_message_from_stderr(result.stderr),
+                msg_type=types.MessageType.Error,
+            )
         # not going to exit just yet, check if black gave us any stdout first
-        
 
     new_source = _match_line_endings(document, result.stdout)
 
@@ -273,7 +282,9 @@ def formatting(_server: server.LanguageServer, params: types.DocumentFormattingP
         return _format(params)
     except Exception as e:
         # gracefully handle error and notify the user
-        LSP_SERVER.show_message_log(traceback.format_exc(), msg_type=types.MessageType.Error)
+        LSP_SERVER.show_message_log(
+            traceback.format_exc(), msg_type=types.MessageType.Error
+        )
         LSP_SERVER.show_message(
             f"Fatal error: {e!r}, please see Output > Black Formatter for more info",
             msg_type=types.MessageType.Error,

--- a/bundled/formatter/format_server.py
+++ b/bundled/formatter/format_server.py
@@ -3,7 +3,6 @@
 """
 Implementation of formatting support over LSP.
 """
-import ast
 import json
 import os
 import pathlib

--- a/package.json
+++ b/package.json
@@ -92,6 +92,12 @@
                     "scope": "resource",
                     "type": "array"
                 },
+                "black-formatter.show-formatting-messages": {
+                    "default": true,
+                    "description": "Whether to show messages in UI when extension didn't format file for any reason.",
+                    "type": "boolean",
+                    "scope": "resource"
+                },
                 "black-formatter.path": {
                     "default": [],
                     "description": "When set to a path to black binary, extension will use that for formatting. NOTE: Using this option may slowdown formatting.",

--- a/package.json
+++ b/package.json
@@ -92,11 +92,17 @@
                     "scope": "resource",
                     "type": "array"
                 },
-                "black-formatter.show-formatting-messages": {
-                    "default": true,
-                    "description": "Whether to show messages in UI when extension didn't format file for any reason.",
-                    "type": "boolean",
-                    "scope": "resource"
+                "black-formatter.showNotification": {
+                    "default": "on-warn",
+                    "description": "When extension is allowed to notifications messages in UI.",
+                    "enum": [
+                        "on-crash",
+                        "on-error",
+                        "on-warn",
+                        "on-message"
+                    ],
+                    "scope": "resource",
+                    "type": "string"
                 },
                 "black-formatter.path": {
                     "default": [],

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -29,6 +29,7 @@ export async function getFormatterExtensionSettings(
             trace: config.get<LoggingLevelSettingType>(`trace`) ?? 'error',
             args: config.get<string[]>(`args`) ?? [],
             severity: config.get<Record<string, string>>(`severity`) ?? {},
+            "show-formatting-messages": config.get<Boolean>(`show-formatting-messages`) ?? true,
             path: config.get<string[]>(`path`) ?? [],
             interpreter: interpreter ?? [],
         };

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -29,7 +29,7 @@ export async function getFormatterExtensionSettings(
             trace: config.get<LoggingLevelSettingType>(`trace`) ?? 'error',
             args: config.get<string[]>(`args`) ?? [],
             severity: config.get<Record<string, string>>(`severity`) ?? {},
-            "show-formatting-messages": config.get<Boolean>(`show-formatting-messages`) ?? true,
+            'show-formatting-messages': config.get<Boolean>(`show-formatting-messages`) ?? true,
             path: config.get<string[]>(`path`) ?? [],
             interpreter: interpreter ?? [],
         };

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -29,7 +29,7 @@ export async function getFormatterExtensionSettings(
             trace: config.get<LoggingLevelSettingType>(`trace`) ?? 'error',
             args: config.get<string[]>(`args`) ?? [],
             severity: config.get<Record<string, string>>(`severity`) ?? {},
-            'show-formatting-messages': config.get<Boolean>(`show-formatting-messages`) ?? true,
+            showNotification: config.get<string[]>(`showNotification`) ?? 'on-warn',
             path: config.get<string[]>(`path`) ?? [],
             interpreter: interpreter ?? [],
         };

--- a/src/test/python_tests/lsp_test_client/utils.py
+++ b/src/test/python_tests/lsp_test_client/utils.py
@@ -50,11 +50,16 @@ def get_initialization_options():
 
     formatter = package_json["formatter"]
     properties = package_json["contributes"]["configuration"]["properties"]
+    
+    def get_setting(name: str): 
+        return properties[f"{formatter['module']}-formatter.{name}"]["default"]
+    
     settings = [
         {
             "trace": "error",
-            "args": properties[f"{formatter['module']}-formatter.args"]["default"],
-            "path": properties[f"{formatter['module']}-formatter.path"]["default"],
+            "args": get_setting("args"),
+            "path": get_setting("path"),
+            "show-formatting-messages": get_setting("show-formatting-messages"),
             "workspace": as_uri(str(PROJECT_ROOT)),
             "interpreter": [],
         }

--- a/src/test/python_tests/lsp_test_client/utils.py
+++ b/src/test/python_tests/lsp_test_client/utils.py
@@ -50,16 +50,16 @@ def get_initialization_options():
 
     formatter = package_json["formatter"]
     properties = package_json["contributes"]["configuration"]["properties"]
-    
-    def get_setting(name: str): 
+
+    def get_setting(name: str):
         return properties[f"{formatter['module']}-formatter.{name}"]["default"]
-    
+
     settings = [
         {
             "trace": "error",
             "args": get_setting("args"),
             "path": get_setting("path"),
-            "show-formatting-messages": get_setting("show-formatting-messages"),
+            "showNotification": get_setting("showNotification"),
             "workspace": as_uri(str(PROJECT_ROOT)),
             "interpreter": [],
         }


### PR DESCRIPTION
Closes #55
Addresses #38

## Changes
1. Show messages on any occasion when extension didn't reformat the file, except when code hasn't been changed by black
2. Add `show-formatting-messages` setting that toggles behaviour in `#1`
3. Process black stderr to display most relevant data first (e.g. line that couldn't be parsed)
4. Change wording/formatting in some error messages

## Checks
- [x] - Tested changes locally via VSCode debugger
- [x] - Made written code comply with linters
- [ ] - Wrote tests to support the changes 

Going to proceed with the last one one once I get overall feedback on changes

