### PR TITLE
Fix mis-escaped string literal

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -261,7 +261,7 @@ def _log_version_info() -> None:
             # This is text we get from running `black --version`
             # black, 22.3.0 (compiled: yes) <--- This is the version we want.
             first_line = result.stdout.splitlines(keepends=False)[0]
-            parts = [v for v in first_line.split(" ") if re.match("\d+\.\d+\S*", v)]
+            parts = [v for v in first_line.split(" ") if re.match(r"\d+\.\d+\S*", v)]
             if len(parts) == 1:
                 actual_version = parts[0]
             else:


### PR DESCRIPTION
Fixes the following:
```
bundled/tool/lsp_server.py:264: DeprecationWarning: invalid escape sequence '\d'
  parts = [v for v in first_line.split(" ") if re.match("\d+\.\d+\S*", v)]
```