### PR TITLE
Use pipe transport to communicate between LSP client server

### DIFF
--- a/bundled/tool/lsp_io.py
+++ b/bundled/tool/lsp_io.py
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""IO handling to communicate with LSP client."""
+
+import argparse
+import contextlib
+import socket
+import sys
+from typing import Optional, Sequence
+
+
+def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stdio", action="store_true")
+    parser.add_argument("--socket", type=int, default=None)
+    parser.add_argument("--pipe", type=str, default=None)
+    parser.add_argument("--clientProcessId", type=int, default=None)
+
+    return parser.parse_args(args)
+
+
+@contextlib.contextmanager
+def use_pipe(pipe_name: str):
+    if sys.platform == "win32":
+        with open(pipe_name, "r+b") as f:
+            yield (f, f)
+    else:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(pipe_name)
+        f = sock.makefile("rwb")
+        yield (f, f)

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -62,6 +62,7 @@ update_environ_path()
 # **********************************************************
 # pylint: disable=wrong-import-position,import-error
 import lsp_edit_utils as edit_utils
+import lsp_io
 import lsp_jsonrpc as jsonrpc
 import lsp_utils as utils
 import lsprotocol.types as lsp
@@ -659,4 +660,10 @@ def log_always(message: str) -> None:
 # Start the server.
 # *****************************************************
 if __name__ == "__main__":
-    LSP_SERVER.start_io()
+    args = lsp_io.parse_args()
+    if args.pipe:
+        with lsp_io.use_pipe(args.pipe) as (rpipe, wpipe):
+            LSP_SERVER.start_io(rpipe, wpipe)
+    else:
+        # default is always the stdio option.
+        LSP_SERVER.start_io()

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -9,6 +9,7 @@ import {
     LanguageClientOptions,
     RevealOutputChannelOn,
     ServerOptions,
+    TransportKind,
 } from 'vscode-languageclient/node';
 import { DEBUG_SERVER_SCRIPT_PATH, SERVER_SCRIPT_PATH } from './constants';
 import { traceError, traceInfo, traceVerbose } from './logging';
@@ -56,6 +57,7 @@ async function createServer(
         command,
         args,
         options: { cwd, env: newEnv },
+        transport: TransportKind.pipe,
     };
 
     // Options to control the language client


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-black-formatter/issues/280

A common issue with `stdio` transport is that some packages can print to `stdout` on load. In this PR we use `pipe` transport which uses Named Pipes on windows, and Unix Domain Sockets on non-windows OSes and should avoid breaking the communication due to stdout printing by tools. 