### PR TITLE
Update min vscode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "black"
     ],
     "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.82.0"
     },
     "categories": [
         "Programming Languages",


### PR DESCRIPTION
Getting this error from the output `Black Formatter` v2024.0.0

```
2024-02-02 13:51:29.951 [info] The language client requires VS Code version ^1.82.0 but received version <my vscode version>
```

Tho, `project.json` only requires `1.74.0`.

This is caused by the bump of `vscode-languageclient` version to 9.0.1.

https://github.com/microsoft/vscode-languageserver-node/blob/4f782ceac1b4444d335a32561bda0ded305c401e/client/package.json#L8