### PR TITLE
Tolerate missing settings in initialize

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -263,9 +263,12 @@ def initialize(params: lsp.InitializeParams) -> None:
     """LSP handler for initialize request."""
     log_to_output(f"CWD Server: {os.getcwd()}")
 
-    GLOBAL_SETTINGS.update(**params.initialization_options.get("globalSettings", {}))
+    init_opts = params.initialization_options
+    if init_opts is None:
+        init_opts = {}
+    GLOBAL_SETTINGS.update(**init_opts.get("globalSettings", {}))
 
-    settings = params.initialization_options["settings"]
+    settings = init_opts.get("settings", {})
     _update_workspace_settings(settings)
     log_to_output(
         f"Settings used to run Server:\r\n{json.dumps(settings, indent=4, ensure_ascii=False)}\r\n"

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -263,9 +263,7 @@ def initialize(params: lsp.InitializeParams) -> None:
     """LSP handler for initialize request."""
     log_to_output(f"CWD Server: {os.getcwd()}")
 
-    init_opts = params.initialization_options
-    if init_opts is None:
-        init_opts = {}
+    init_opts = params.initialization_options or {}
     GLOBAL_SETTINGS.update(**init_opts.get("globalSettings", {}))
 
     settings = init_opts.get("settings", {})


### PR DESCRIPTION
This is needed in order to get the language server to go with [helix](https://github.com/helix-editor/helix/), using configuration as follows (in `languages.toml`):

```toml
[language-server.black-lsp]
command = "black-lsp"
args = ["--stdio"]
config = {}

[[language]]
name = "python"
language-servers = [
  "black-lsp"
]
```

Helix appears to pass `null` for `initializationOptions`, which appears to be allowed according to [the spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize).