### PR TITLE
revert to 2025.1.0-dev still more changes to go in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "black-formatter",
-    "version": "2025.2.0",
+    "version": "2025.1.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "black-formatter",
-            "version": "2025.2.0",
+            "version": "2025.1.0-dev",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-extension": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "black-formatter",
     "displayName": "Black Formatter",
     "description": "%extension.description%",
-    "version": "2025.2.0",
+    "version": "2025.1.0-dev",
     "preview": true,
     "serverInfo": {
         "name": "Black",


### PR DESCRIPTION
revert: https://github.com/microsoft/vscode-black-formatter/pull/559 temporarly since there are more changes that need to go in.