### PR TITLE
fix: bug Modified to trigger runServer when .black configuration file is updated #569

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,10 +71,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }
     };
 
-    configWatcherDisposable = createConfigFileWatcher(runServer);
-
     context.subscriptions.push(
-        configWatcherDisposable,
+        await createConfigFileWatcher(runServer),
         onDidChangePythonInterpreter(async () => {
             await runServer();
         }),


### PR DESCRIPTION
Here are the changes:

- Added file watcher to monitor changes to .black configuration file in user's home directory
- When .black file is modified, runServer is automatically executed to refresh settings

Fixes #569