### PR TITLE
revert back to public npm when building locally

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,4 @@
-# Use the Azure Artifacts *npm* registry endpoint (not NuGet v3) so npm can resolve tarballs.
-# This matches the pipeline AZURE_ARTIFACTS_FEED value.
-registry=https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/
-
-
-
+# Force public npm registry to avoid CI auth (E401) when no token is provided
+registry=https://registry.npmjs.org/
+# Do not require auth for public installs
+always-auth=false


### PR DESCRIPTION
Variable `AZURE_ARTIFACTS_FEED` is overriding the npm feed in azure and in setup.yml template we add our auth info.

when building locally we dont want to have to auth so revert changes to .nmprc