### PR TITLE
Agentic Workflow: Check tool repo for issue triage

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -23,7 +23,7 @@
 #
 # When a new issue is opened — or when a maintainer comments `/triage-issue` on an existing issue — analyze its root cause, check whether the same issue could affect other extensions built from the microsoft/vscode-python-tools-extension-template, and look for related open issues on the upstream Black repository (psf/black). If applicable, suggest an upstream fix and surface relevant Black issues to the reporter.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"d68ba79a099ef2ca62a72c74850f17a09e981f3a8e995465473ca24739b43a7a","compiler_version":"v0.47.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"20839e5fc4d3ac84605f9fea282593eee1ac5dc215c81fa115bb5865a5627644","compiler_version":"v0.47.5"}
 
 name: 'Issue Triage'
 'on':
@@ -290,6 +290,10 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Checkout template repo
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -25,6 +25,10 @@ safe-outputs:
   noop:
     max: 1
 steps:
+- name: Checkout repository
+  uses: actions/checkout@v5
+  with:
+    persist-credentials: false
 - name: Checkout template repo
   uses: actions/checkout@v5
   with:


### PR DESCRIPTION
This pull request updates the issue triage agentic workflow to:

- **Trigger on \/triage-issue\ comments** in addition to new issues (adds \issue_comment\ event)
- **Search upstream Black repository** (\psf/black\) for related open issues
- **Rename workflow** from 'Issue Root-Cause & Template Check' to 'Issue Triage' for clarity
- **Add upstream issues section** to the analysis comment template
- **Add re-triage instructions** so maintainers can re-run analysis with \/triage-issue\

Mirrors the changes from https://github.com/microsoft/vscode-isort/pull/538.