### PR TITLE
Refactor: backport shared test coverage (envFile + configWatcher dispose)

### DIFF
--- a/src/test/ts_tests/tests/common/configWatcher.unit.test.ts
+++ b/src/test/ts_tests/tests/common/configWatcher.unit.test.ts
@@ -9,34 +9,44 @@ import { BLACK_CONFIG_FILES } from '../../../../common/constants';
 
 interface MockFileSystemWatcher {
     watcher: FileSystemWatcher;
+    changeDisposable: { dispose: sinon.SinonStub };
+    createDisposable: { dispose: sinon.SinonStub };
+    deleteDisposable: { dispose: sinon.SinonStub };
     fireDidCreate(): Promise<void>;
     fireDidChange(): Promise<void>;
     fireDidDelete(): Promise<void>;
 }
 
-function createMockFileSystemWatcher(): MockFileSystemWatcher {
+function createMockFileSystemWatcher(sb: sinon.SinonSandbox): MockFileSystemWatcher {
+    const changeDisposable = { dispose: sb.stub() };
+    const createDisposable = { dispose: sb.stub() };
+    const deleteDisposable = { dispose: sb.stub() };
+
     let onDidChangeHandler: (() => Promise<void>) | undefined;
     let onDidCreateHandler: (() => Promise<void>) | undefined;
     let onDidDeleteHandler: (() => Promise<void>) | undefined;
 
     const watcher = {
-        onDidChange: (handler: () => Promise<void>): Disposable => {
+        onDidChange: sb.stub().callsFake((handler: () => Promise<void>): Disposable => {
             onDidChangeHandler = handler;
-            return { dispose: () => {} };
-        },
-        onDidCreate: (handler: () => Promise<void>): Disposable => {
+            return changeDisposable as unknown as Disposable;
+        }),
+        onDidCreate: sb.stub().callsFake((handler: () => Promise<void>): Disposable => {
             onDidCreateHandler = handler;
-            return { dispose: () => {} };
-        },
-        onDidDelete: (handler: () => Promise<void>): Disposable => {
+            return createDisposable as unknown as Disposable;
+        }),
+        onDidDelete: sb.stub().callsFake((handler: () => Promise<void>): Disposable => {
             onDidDeleteHandler = handler;
-            return { dispose: () => {} };
-        },
-        dispose: () => {},
+            return deleteDisposable as unknown as Disposable;
+        }),
+        dispose: sb.stub(),
     } as unknown as FileSystemWatcher;
 
     return {
         watcher,
+        changeDisposable,
+        createDisposable,
+        deleteDisposable,
         fireDidCreate: async () => {
             if (onDidCreateHandler) {
                 await onDidCreateHandler();
@@ -59,10 +69,21 @@ suite('Config File Watcher Tests', () => {
     let sandbox: sinon.SinonSandbox;
     let createFileSystemWatcherStub: sinon.SinonStub;
     let mockWatchers: MockFileSystemWatcher[];
+    let onConfigChangedCallback: sinon.SinonStub;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockWatcher: any;
+    let changeDisposable: { dispose: sinon.SinonStub };
+    let createDisposable: { dispose: sinon.SinonStub };
+    let deleteDisposable: { dispose: sinon.SinonStub };
 
     setup(() => {
         sandbox = sinon.createSandbox();
-        mockWatchers = BLACK_CONFIG_FILES.map(() => createMockFileSystemWatcher());
+        mockWatchers = BLACK_CONFIG_FILES.map(() => createMockFileSystemWatcher(sandbox));
+        onConfigChangedCallback = sandbox.stub().resolves();
+        mockWatcher = mockWatchers[0].watcher;
+        changeDisposable = mockWatchers[0].changeDisposable;
+        createDisposable = mockWatchers[0].createDisposable;
+        deleteDisposable = mockWatchers[0].deleteDisposable;
 
         let watcherIndex = 0;
         createFileSystemWatcherStub = sandbox.stub(workspace, 'createFileSystemWatcher').callsFake(() => {
@@ -141,5 +162,29 @@ suite('Config File Watcher Tests', () => {
         for (const d of disposables) {
             assert.isFunction(d.dispose);
         }
+    });
+
+    test('Should dispose all subscriptions and watcher on dispose', () => {
+        const watchers = createConfigFileWatchers(onConfigChangedCallback);
+
+        watchers[0].dispose();
+
+        assert.strictEqual(changeDisposable.dispose.callCount, 1, 'Change subscription should be disposed');
+        assert.strictEqual(createDisposable.dispose.callCount, 1, 'Create subscription should be disposed');
+        assert.strictEqual(deleteDisposable.dispose.callCount, 1, 'Delete subscription should be disposed');
+        assert.strictEqual(mockWatcher.dispose.callCount, 1, 'Watcher should be disposed');
+    });
+
+    test('Should not call callback after dispose', () => {
+        const watchers = createConfigFileWatchers(onConfigChangedCallback);
+
+        // Dispose the watcher
+        watchers[0].dispose();
+
+        // Get the handlers and call them after disposal
+        const changeHandler = mockWatcher.onDidChange.getCall(0).args[0];
+        changeHandler();
+
+        assert.strictEqual(onConfigChangedCallback.callCount, 0, 'Callback should not be called after dispose');
     });
 });

--- a/src/test/ts_tests/tests/common/envFile.unit.test.ts
+++ b/src/test/ts_tests/tests/common/envFile.unit.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { Uri, WorkspaceFolder } from 'vscode';
+import { getEnvFileVars } from '../../../../common/envFile';
+import * as vscodeapi from '../../../../common/vscodeapi';
+
+// Use real files instead of stubbing fs-extra (whose exports are non-configurable).
+suite('getEnvFileVars Tests', () => {
+    let getConfigurationStub: sinon.SinonStub;
+
+    const fixtureDir = path.join(__dirname, '.envfile-test-fixtures');
+
+    const workspaceFolder: WorkspaceFolder = {
+        uri: Uri.file(fixtureDir),
+        name: 'workspace',
+        index: 0,
+    };
+
+    setup(async () => {
+        await fs.ensureDir(fixtureDir);
+        getConfigurationStub = sinon.stub(vscodeapi, 'getConfiguration');
+    });
+
+    teardown(async () => {
+        sinon.restore();
+        await fs.remove(fixtureDir);
+    });
+
+    test('returns parsed variables from existing .env file', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env'), 'FOO=bar\nBAZ=qux\n');
+        getConfigurationStub.returns({
+            get: (_key: string, defaultValue: string) => defaultValue,
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { FOO: 'bar', BAZ: 'qux' });
+    });
+
+    test('returns empty object for missing file', async () => {
+        getConfigurationStub.returns({
+            get: (_key: string, defaultValue: string) => defaultValue,
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        assert.deepStrictEqual(vars, {});
+    });
+
+    test('resolves ${workspaceFolder} in path', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env.test'), 'KEY=value\n');
+        getConfigurationStub.returns({
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            get: (_key: string, _defaultValue: string) => '${workspaceFolder}/.env.test',
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { KEY: 'value' });
+    });
+
+    test('resolves relative paths', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env.local'), 'RELATIVE=yes\n');
+        getConfigurationStub.returns({
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            get: (_key: string, _defaultValue: string) => '.env.local',
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { RELATIVE: 'yes' });
+    });
+});


### PR DESCRIPTION
Backports shared test coverage from sibling extension repos to ensure consistent test coverage before shared package extraction.

### Changes
- **envFile.unit.test.ts** (4 tests): Tests for \getEnvFileVars\ — env file parsing, missing file handling, variable resolution. Copied from isort.
- **configWatcher dispose** (2 tests): Tests that disposal properly cleans up subscriptions and prevents post-dispose callbacks. Backported from pylint.

Part of microsoft/vscode-python-tools-extension-template#290