### PR TITLE
Add manual validation stage to stable release pipeline

### DIFF
--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -84,9 +84,23 @@ extends:
               standardizedVersioning: true
               customNPMRegistry: $(AZURE_ARTIFACTS_FEED)
 
+      - stage: WaitForValidation
+        displayName: Wait for Validation
+        dependsOn: Build
+        jobs:
+          - job: wait_for_validation
+            displayName: Wait for manual validation
+            pool: server
+            steps:
+              - task: ManualValidation@0
+                timeoutInMinutes: 1440 # task times out in 1 day
+                inputs:
+                  notifyUsers: 'plseng@microsoft.com'
+                  instructions: 'please test the latest draft release then publish it.'
+                  onTimeout: 'reject'
       - stage: Publish
         displayName: Publish Extension
-        dependsOn: Build
+        dependsOn: WaitForValidation
         jobs:
           - template: azure-pipelines/extension/templates/jobs/publish-extension.yml@templates
             parameters:


### PR DESCRIPTION
Adds a `WaitForValidation` stage between Build and Publish in the stable pipeline. The pipeline will pause for manual approval (24h timeout, notifies plseng@microsoft.com) before publishing, giving time to test the draft release.