### PR TITLE
Enable publishExtension in stable release pipeline

### DIFF
--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -128,8 +128,21 @@ When the pipeline completes signing, it will pause for manual validation before 
 
 ## Done
 
-Once the pipeline has published successfully:
-- A GitHub release will be created at the release tag (e.g. `v2026.4.0` — *example*)
-- The extension will be live on the marketplace as a stable release
+Once the pipeline has published successfully, verify the release:
+
+1. **Check GitHub Releases** — confirm the new version appears on the releases page:
+   `
+   gh release list --repo microsoft/vscode-black-formatter --limit 5
+   `
+   Or visit: https://github.com/microsoft/vscode-black-formatter/releases
+
+2. **Verify the release tag** matches the expected version (e.g. `v2026.4.0` — *example*):
+   `
+   gh release view v<VERSION> --repo microsoft/vscode-black-formatter
+   `
+
+> ✋ **Confirm**: Does the new version appear on the [releases page](https://github.com/microsoft/vscode-black-formatter/releases)?
+
+- The extension should now be live on the VS Code Marketplace as a stable release.
 
 Congratulations on the release! 🎉

--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -131,15 +131,15 @@ When the pipeline completes signing, it will pause for manual validation before 
 Once the pipeline has published successfully, verify the release:
 
 1. **Check GitHub Releases** — confirm the new version appears on the releases page:
-   `
+   ```
    gh release list --repo microsoft/vscode-black-formatter --limit 5
-   `
+   ```
    Or visit: https://github.com/microsoft/vscode-black-formatter/releases
 
 2. **Verify the release tag** matches the expected version (e.g. `v2026.4.0` — *example*):
-   `
+   ```
    gh release view v<VERSION> --repo microsoft/vscode-black-formatter
-   `
+   ```
 
 > ✋ **Confirm**: Does the new version appear on the [releases page](https://github.com/microsoft/vscode-black-formatter/releases)?
 

--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -32,7 +32,7 @@ parameters:
   - name: publishExtension
     displayName: 🚀 Publish Extension
     type: boolean
-    default: false
+    default: true
 
   - name: buildSteps
     type: stepList


### PR DESCRIPTION
Set `publishExtension` parameter default to `true` in `build/azure-devdiv-pipeline.stable.yml` so stable releases publish the extension automatically.