### PR TITLE
feat: wire vscode-common-python-lsp shared package (Stage 1)

### DIFF
--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -1,216 +1,85 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-"""Utility functions and classes for use with running tools over LSP."""
+"""Utility functions and classes for use with running tools over LSP.
+
+Thin wrapper: delegates to vscode-common-python-lsp shared package,
+providing backward-compatible names used by lsp_server.py.
+"""
 
 from __future__ import annotations
 
-import contextlib
-import fnmatch
-import io
-import logging
-import os
-import pathlib
-import runpy
-import site
-import subprocess
-import sys
-import sysconfig
-import threading
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import Sequence
 
-# Save the working directory used when loading this module
-SERVER_CWD = os.getcwd()
-CWD_LOCK = threading.Lock()
-
-
-def as_list(content: Union[Any, List[Any], Tuple[Any]]) -> List[Any]:
-    """Ensures we always get a list"""
-    if isinstance(content, (list, tuple)):
-        return list(content)
-    return [content]
-
-
-def _get_sys_config_paths() -> List[str]:
-    """Returns paths from sysconfig.get_paths()."""
-    return [
-        path
-        for group, path in sysconfig.get_paths().items()
-        if group not in ["data", "platdata", "scripts"]
-    ]
-
-
-def _get_extensions_dir() -> List[str]:
-    """This is the extensions folder under ~/.vscode or ~/.vscode-server."""
-
-    # The path here is calculated relative to the tool
-    # this is because users can launch VS Code with custom
-    # extensions folder using the --extensions-dir argument
-    path = pathlib.Path(__file__).parent.parent.parent.parent
-    #                              ^     bundled  ^  extensions
-    #                            tool        <extension>
-    if path.name == "extensions":
-        return [os.fspath(path)]
-    return []
-
-
-_stdlib_paths = set(
-    str(pathlib.Path(p).resolve())
-    for p in (
-        as_list(site.getsitepackages())
-        + as_list(site.getusersitepackages())
-        + _get_sys_config_paths()
-        + _get_extensions_dir()
-    )
+from vscode_common_python_lsp import (
+    CWD_LOCK,
+    SERVER_CWD,
+    CustomIO,
+    PythonFileKind,
+    QuickFixRegistrationError,
+    RunResult,
+    as_list,
+    change_cwd,
+    classify_python_file,
+    is_current_interpreter,
+    is_match,
+    is_same_path,
+    normalize_path,
+    redirect_io,
+    run_api,
+    run_module as _run_module,
+    run_path as _run_path,
+    substitute_attr,
 )
 
+__all__ = [
+    "SERVER_CWD",
+    "CWD_LOCK",
+    "as_list",
+    "normalize_path",
+    "is_same_path",
+    "is_current_interpreter",
+    "is_user_site_packages_file",
+    "is_system_site_packages_file",
+    "is_stdlib_file",
+    "is_match",
+    "RunResult",
+    "CustomIO",
+    "substitute_attr",
+    "redirect_io",
+    "change_cwd",
+    "run_module",
+    "run_path",
+    "run_api",
+    "QuickFixRegistrationError",
+]
 
-def is_same_path(file_path1: str, file_path2: str) -> bool:
-    """Returns true if two paths are the same."""
-    return pathlib.Path(file_path1) == pathlib.Path(file_path2)
+
+# Compatibility wrappers: the shared package uses classify_python_file()
+# returning a PythonFileKind enum; these preserve the old per-kind API.
 
 
-def normalize_path(file_path: str, resolve_symlinks: bool = True) -> str:
-    """Returns normalized path."""
-    path = pathlib.Path(file_path)
-    if resolve_symlinks:
-        path = path.resolve()
-    return str(path)
+def is_user_site_packages_file(file_path: str) -> bool:
+    """Return True if the file belongs to the user site-packages directory."""
+    return classify_python_file(file_path) == PythonFileKind.USER_SITE
 
 
-def is_current_interpreter(executable: str) -> bool:
-    """Returns true if the executable path is same as the current interpreter."""
-    return is_same_path(executable, sys.executable)
+def is_system_site_packages_file(file_path: str) -> bool:
+    """Return True if the file belongs to system site-packages directories."""
+    return classify_python_file(file_path) == PythonFileKind.SYSTEM_SITE
 
 
 def is_stdlib_file(file_path: str) -> bool:
-    """Return True if the file belongs to the standard library."""
-    normalized_path = str(pathlib.Path(file_path).resolve())
-    return any(normalized_path.startswith(path) for path in _stdlib_paths)
+    """Return True if the file belongs to a non-user Python path.
 
-
-def _get_relative_path(file_path: str, workspace_root: str) -> str:
-    """Returns the file path relative to the workspace root.
-
-    Falls back to the original path if the workspace root is empty or
-    the paths are on different drives (Windows).
+    The original implementation included stdlib, system site-packages,
+    user site-packages, and extensions dir. Matching that broad semantics.
     """
-    if not workspace_root:
-        return pathlib.Path(file_path).as_posix()
-    try:
-        return pathlib.Path(file_path).relative_to(workspace_root).as_posix()
-    except ValueError:
-        return pathlib.Path(file_path).as_posix()
+    return classify_python_file(file_path) is not None
 
 
-def is_match(patterns: List[str], file_path: str, workspace_root: str = None) -> bool:
-    """Returns true if the file matches one of the fnmatch patterns."""
-    if not patterns:
-        return False
-    relative_path = (
-        _get_relative_path(file_path, workspace_root) if workspace_root else file_path
-    )
-    file_name = pathlib.Path(file_path).name
-    return any(
-        fnmatch.fnmatch(relative_path, pattern)
-        or (not pattern.startswith("/") and fnmatch.fnmatch(file_name, pattern))
-        for pattern in patterns
-    )
-
-
-# pylint: disable-next=too-few-public-methods
-class RunResult:
-    """Object to hold result from running tool."""
-
-    def __init__(
-        self, stdout: str, stderr: str, exit_code: Optional[Union[int, str]] = None
-    ):
-        self.stdout: str = stdout
-        self.stderr: str = stderr
-        self.exit_code: Optional[Union[int, str]] = exit_code
-
-
-class CustomIO(io.TextIOWrapper):
-    """Custom stream object to replace stdio."""
-
-    name = None
-
-    def __init__(self, name, encoding="utf-8", newline=None):
-        self._buffer = io.BytesIO()
-        self._buffer.name = name
-        super().__init__(self._buffer, encoding=encoding, newline=newline)
-
-    def close(self):
-        """Provide this close method which is used by some tools."""
-        # This is intentionally empty.
-
-    def get_value(self) -> str:
-        """Returns value from the buffer as string."""
-        self.seek(0)
-        return self.read()
-
-
-@contextlib.contextmanager
-def substitute_attr(obj: Any, attribute: str, new_value: Any):
-    """Manage object attributes context when using runpy.run_module()."""
-    old_value = getattr(obj, attribute)
-    setattr(obj, attribute, new_value)
-    yield
-    setattr(obj, attribute, old_value)
-
-
-@contextlib.contextmanager
-def redirect_io(stream: str, new_stream):
-    """Redirect stdio streams to a custom stream."""
-    old_stream = getattr(sys, stream)
-    setattr(sys, stream, new_stream)
-    yield
-    setattr(sys, stream, old_stream)
-
-
-@contextlib.contextmanager
-def change_cwd(new_cwd):
-    """Change working directory before running code."""
-    try:
-        os.chdir(new_cwd)
-    except OSError as e:
-        logging.warning(
-            "Failed to change directory to %r, running in %r instead: %s",
-            new_cwd,
-            SERVER_CWD,
-            e,
-        )
-        yield
-        return
-    try:
-        yield
-    finally:
-        os.chdir(SERVER_CWD)
-
-
-def _run_module(
-    module: str, argv: Sequence[str], use_stdin: bool, source: str = None
-) -> RunResult:
-    """Runs as a module."""
-    str_output = CustomIO("<stdout>", encoding="utf-8")
-    str_error = CustomIO("<stderr>", encoding="utf-8")
-    exit_code = None
-
-    try:
-        with substitute_attr(sys, "argv", argv):
-            with redirect_io("stdout", str_output):
-                with redirect_io("stderr", str_error):
-                    if use_stdin and source is not None:
-                        str_input = CustomIO("<stdin>", encoding="utf-8", newline="\n")
-                        with redirect_io("stdin", str_input):
-                            str_input.write(source)
-                            str_input.seek(0)
-                            runpy.run_module(module, run_name="__main__")
-                    else:
-                        runpy.run_module(module, run_name="__main__")
-    except SystemExit as ex:
-        exit_code = ex.code
-
-    return RunResult(str_output.get_value(), str_error.get_value(), exit_code)
+# Compatibility wrappers: the shared package's run_module does not accept
+# a timeout parameter (in-process execution cannot be reliably timed out).
+# The original lsp_utils accepted it as a no-op.  run_path passes through.
 
 
 def run_module(
@@ -221,16 +90,8 @@ def run_module(
     source: str = None,
     timeout: float = None,
 ) -> RunResult:
-    """Runs as a module."""
-    if timeout is not None:
-        # In-process execution via runpy cannot be reliably timed out.
-        # Timeout is only effective for subprocess (run_path) and JSON-RPC paths.
-        pass
-    with CWD_LOCK:
-        if is_same_path(os.getcwd(), cwd):
-            return _run_module(module, argv, use_stdin, source)
-        with change_cwd(cwd):
-            return _run_module(module, argv, use_stdin, source)
+    """Runs as a module. timeout is accepted for compatibility but ignored."""
+    return _run_module(module, argv, use_stdin, cwd, source)
 
 
 def run_path(
@@ -241,69 +102,4 @@ def run_path(
     timeout: float = None,
 ) -> RunResult:
     """Runs as an executable."""
-    if use_stdin:
-        with subprocess.Popen(
-            argv,
-            encoding="utf-8",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            stdin=subprocess.PIPE,
-            cwd=cwd,
-        ) as process:
-            try:
-                return RunResult(*process.communicate(input=source, timeout=timeout))
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.communicate()
-                raise
-    else:
-        result = subprocess.run(
-            argv,
-            encoding="utf-8",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-            cwd=cwd,
-            timeout=timeout,
-        )
-        return RunResult(result.stdout, result.stderr)
-
-
-def run_api(
-    callback: Callable[[Sequence[str], CustomIO, CustomIO, CustomIO | None], None],
-    argv: Sequence[str],
-    use_stdin: bool,
-    cwd: str,
-    source: str = None,
-) -> RunResult:
-    """Run a API."""
-    with CWD_LOCK:
-        if is_same_path(os.getcwd(), cwd):
-            return _run_api(callback, argv, use_stdin, source)
-        with change_cwd(cwd):
-            return _run_api(callback, argv, use_stdin, source)
-
-
-def _run_api(
-    callback: Callable[[Sequence[str], CustomIO, CustomIO, CustomIO | None], None],
-    argv: Sequence[str],
-    use_stdin: bool,
-    source: str = None,
-) -> RunResult:
-    str_output = CustomIO("<stdout>", encoding="utf-8")
-    str_error = CustomIO("<stderr>", encoding="utf-8")
-
-    with contextlib.suppress(SystemExit):
-        with substitute_attr(sys, "argv", argv):
-            with redirect_io("stdout", str_output):
-                with redirect_io("stderr", str_error):
-                    if use_stdin and source is not None:
-                        str_input = CustomIO("<stdin>", encoding="utf-8", newline="\n")
-                        with redirect_io("stdin", str_input):
-                            str_input.write(source)
-                            str_input.seek(0)
-                            callback(argv, str_output, str_error, str_input)
-                    else:
-                        callback(argv, str_output, str_error)
-
-    return RunResult(str_output.get_value(), str_error.get_value())
+    return _run_path(argv, use_stdin, cwd, source, timeout=timeout)

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -26,10 +26,10 @@ from vscode_common_python_lsp import (
     normalize_path,
     redirect_io,
     run_api,
-    run_module as _run_module,
-    run_path as _run_path,
-    substitute_attr,
 )
+from vscode_common_python_lsp import run_module as _run_module
+from vscode_common_python_lsp import run_path as _run_path
+from vscode_common_python_lsp import substitute_attr
 
 __all__ = [
     "SERVER_CWD",

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -29,7 +29,9 @@ from vscode_common_python_lsp import (
 )
 from vscode_common_python_lsp import run_module as _run_module
 from vscode_common_python_lsp import run_path as _run_path
-from vscode_common_python_lsp import substitute_attr
+from vscode_common_python_lsp import (
+    substitute_attr,
+)
 
 __all__ = [
     "SERVER_CWD",

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,6 +112,14 @@ def install_bundled_libs(session):
     """Installs the libraries that will be bundled with the extension."""
     session.install("wheel")
     _install_bundle(session)
+    session.install(
+        "-t",
+        "./bundled/libs",
+        "--no-cache-dir",
+        "--no-deps",
+        "--upgrade",
+        "vscode-common-python-lsp==0.3.0",
+    )
 
 
 @nox.session(python="3.10")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "black-formatter",
-    "version": "2026.3.0-dev",
+    "version": "2026.5.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "black-formatter",
-            "version": "2026.3.0-dev",
+            "version": "2026.5.0-dev",
             "license": "MIT",
             "dependencies": {
+                "@vscode/common-python-lsp": "0.2.1",
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/python-extension": "^1.0.5",
                 "dotenv": "^17.4.0",
@@ -1401,6 +1402,84 @@
             "engines": {
                 "node": ">=20.0.0"
             }
+        },
+        "node_modules/@vscode/common-python-lsp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.2.1.tgz",
+            "integrity": "sha512-FNYU9DCwa4InI6bGkmALw0JcEMEytRD2hp9wz3PNZ7pV1qtVB/Uvhj3rxr0fe9S9iXB4+GPF/tiF+xVmLhGQIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+                "@vscode/python-extension": "^1.0.6",
+                "dotenv": "^17.4.1",
+                "fs-extra": "^11.3.4",
+                "semver": "^7.7.4",
+                "vscode-languageclient": "^8.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "vscode": "^1.74.0"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "license": "MIT",
+            "dependencies": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "engines": {
+                "vscode": "^1.67.0"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
+            "license": "MIT"
         },
         "node_modules/@vscode/python-environments": {
             "version": "1.0.0",
@@ -2896,9 +2975,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "17.4.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-            "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -8685,6 +8764,66 @@
                 "tslib": "^2.6.2"
             }
         },
+        "@vscode/common-python-lsp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.2.1.tgz",
+            "integrity": "sha512-FNYU9DCwa4InI6bGkmALw0JcEMEytRD2hp9wz3PNZ7pV1qtVB/Uvhj3rxr0fe9S9iXB4+GPF/tiF+xVmLhGQIQ==",
+            "requires": {
+                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+                "@vscode/python-extension": "^1.0.6",
+                "dotenv": "^17.4.1",
+                "fs-extra": "^11.3.4",
+                "semver": "^7.7.4",
+                "vscode-languageclient": "^8.1.0"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+                    "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.9",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+                    "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                },
+                "vscode-jsonrpc": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+                    "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
+                },
+                "vscode-languageclient": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+                    "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+                    "requires": {
+                        "minimatch": "^5.1.0",
+                        "semver": "^7.3.7",
+                        "vscode-languageserver-protocol": "3.17.3"
+                    }
+                },
+                "vscode-languageserver-protocol": {
+                    "version": "3.17.3",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+                    "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+                    "requires": {
+                        "vscode-jsonrpc": "8.1.0",
+                        "vscode-languageserver-types": "3.17.3"
+                    }
+                },
+                "vscode-languageserver-types": {
+                    "version": "3.17.3",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+                    "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+                }
+            }
+        },
         "@vscode/python-environments": {
             "version": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
             "integrity": "sha1-AQxJi6ysjdysdHVWlc/H3XEbHfU="
@@ -9709,9 +9848,9 @@
             }
         },
         "dotenv": {
-            "version": "17.4.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-            "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ=="
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
         },
         "dunder-proto": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,8 @@
         "dotenv": "^17.4.0",
         "fs-extra": "^11.3.4",
         "semver": "^7.7.4",
-        "vscode-languageclient": "^9.0.1"
+        "vscode-languageclient": "^9.0.1",
+        "@vscode/common-python-lsp": "0.2.1"
     },
     "devDependencies": {
         "@eslint/js": "^9.33.0",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
+import { ToolConfig } from '@vscode/common-python-lsp';
 
 export const EXTENSION_ID = 'ms-python.black-formatter';
 const folderName = path.basename(__dirname);
@@ -15,3 +16,31 @@ export const PYTHON_MINOR = 10;
 export const PYTHON_VERSION = `${PYTHON_MAJOR}.${PYTHON_MINOR}`;
 export const LS_SERVER_RESTART_DELAY = 1000;
 export const BLACK_CONFIG_FILES = ['pyproject.toml', '.black', 'setup.cfg', 'tox.ini'];
+
+export const BLACK_TOOL_CONFIG: ToolConfig = {
+    toolId: 'black-formatter',
+    toolDisplayName: 'Black',
+    toolModule: 'black',
+    minimumPythonVersion: { major: PYTHON_MAJOR, minor: PYTHON_MINOR },
+    configFiles: BLACK_CONFIG_FILES,
+    serverScript: SERVER_SCRIPT_PATH,
+    debugServerScript: DEBUG_SERVER_SCRIPT_PATH,
+    settingsDefaults: {
+        args: [],
+        cwd: '${workspaceFolder}',
+        importStrategy: 'useBundled',
+        interpreter: [],
+        path: [],
+        showNotifications: 'off',
+        serverTransport: 'stdio',
+    },
+    trackedSettings: [
+        'black-formatter.args',
+        'black-formatter.cwd',
+        'black-formatter.path',
+        'black-formatter.interpreter',
+        'black-formatter.importStrategy',
+        'black-formatter.showNotifications',
+        'black-formatter.serverTransport',
+    ],
+};

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -5,8 +5,9 @@ import { PythonEnvironmentApi, PythonEnvironment, PythonEnvironments } from '@vs
 import { commands, Disposable, Event, EventEmitter, Uri } from 'vscode';
 import { traceError, traceLog } from './logging';
 import { PythonExtension, ResolvedEnvironment } from '@vscode/python-extension';
+import { PythonEnvironmentsProvider } from '@vscode/common-python-lsp';
 import * as semver from 'semver';
-import { PYTHON_MAJOR, PYTHON_MINOR, PYTHON_VERSION } from './constants';
+import { BLACK_TOOL_CONFIG, PYTHON_MAJOR, PYTHON_MINOR, PYTHON_VERSION } from './constants';
 import { getProjectRoot } from './utilities';
 
 export interface IInterpreterDetails {
@@ -224,4 +225,13 @@ export function checkVersion(resolved: ResolvedEnvironment | undefined): boolean
 export function resetCachedApis(): void {
     _api = undefined;
     _envsApi = undefined;
+}
+
+let _pythonProvider: PythonEnvironmentsProvider | undefined;
+
+export function getPythonProvider(): PythonEnvironmentsProvider {
+    if (!_pythonProvider) {
+        _pythonProvider = new PythonEnvironmentsProvider(BLACK_TOOL_CONFIG);
+    }
+    return _pythonProvider;
 }

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,101 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
-import * as fsapi from 'fs-extra';
-import { Disposable, env, l10n, LanguageStatusSeverity, LogOutputChannel, Uri, WorkspaceFolder } from 'vscode';
-import { State } from 'vscode-languageclient';
+// Thin wrapper: delegates to vscode-common-python-lsp shared package.
+
+import { Disposable, LogOutputChannel } from 'vscode';
+import { LanguageClient } from 'vscode-languageclient/node';
 import {
-    LanguageClient,
-    LanguageClientOptions,
-    RevealOutputChannelOn,
-    ServerOptions,
-} from 'vscode-languageclient/node';
-import { DEBUG_SERVER_SCRIPT_PATH, SERVER_SCRIPT_PATH } from './constants';
-import { getEnvFileVars } from './envFile';
-import { traceError, traceInfo, traceVerbose } from './logging';
-import { getDebuggerPath } from './python';
-import { getExtensionSettings, getGlobalSettings, getServerTransport, ISettings } from './settings';
-import { getDocumentSelector, getLSClientTraceLevel } from './utilities';
-import { updateStatus } from './status';
-import { unregisterEmptyFormatter } from './nullFormatter';
-import { getWorkspaceFolders } from './vscodeapi';
+    IBaseSettings,
+    getServerCwd as _getServerCwd,
+    restartServer as _restartServer,
+} from '@vscode/common-python-lsp';
+import { BLACK_TOOL_CONFIG } from './constants';
+import { traceError } from './logging';
+import { getPythonProvider } from './python';
+import { ISettings } from './settings';
 
-export type IInitOptions = { settings: ISettings[]; globalSettings: ISettings };
+export type { IInitOptions } from '@vscode/common-python-lsp';
 
-async function createServer(
-    settings: ISettings,
-    serverId: string,
-    serverName: string,
-    outputChannel: LogOutputChannel,
-    initializationOptions: IInitOptions,
-): Promise<LanguageClient> {
-    const command = settings.interpreter[0];
-    const workspaceUri = Uri.parse(settings.workspace);
-    const cwd = settings.cwd === '${fileDirname}' ? workspaceUri.fsPath : settings.cwd;
-
-    // Load environment variables from envFile (python.envFile setting or .env)
-    // Environment variables from .env are loaded once at server creation time.
-    // Changes to the .env file require restarting the extension to take effect.
-    // A file watcher for hot-reload could be added in a future enhancement.
-    const workspaceFolder: WorkspaceFolder = getWorkspaceFolders().find(
-        (w) => w.uri.toString() === settings.workspace,
-    ) ?? { uri: workspaceUri, name: path.basename(workspaceUri.fsPath), index: 0 };
-    const envFileVars = await getEnvFileVars(workspaceFolder);
-
-    // Build environment: .env provides defaults, system env wins for conflicts.
-    // Path-like variables are appended rather than overridden.
-    const newEnv = { ...envFileVars, ...process.env };
-
-    // Append .env PYTHONPATH/PATH to system values instead of replacing
-    for (const pathVar of ['PYTHONPATH', 'PATH']) {
-        if (envFileVars[pathVar] && process.env[pathVar]) {
-            newEnv[pathVar] = process.env[pathVar] + path.delimiter + envFileVars[pathVar];
-        }
-    }
-
-    // Set debugger path needed for debugging python code.
-    const debuggerPath = await getDebuggerPath();
-    const isDebugScript = await fsapi.pathExists(DEBUG_SERVER_SCRIPT_PATH);
-    if (newEnv.USE_DEBUGPY && debuggerPath) {
-        newEnv.DEBUGPY_PATH = debuggerPath;
-    } else {
-        newEnv.USE_DEBUGPY = 'False';
-    }
-
-    // Set import strategy
-    newEnv.LS_IMPORT_STRATEGY = settings.importStrategy;
-
-    // Set notification type
-    newEnv.LS_SHOW_NOTIFICATION = settings.showNotifications;
-
-    const args =
-        newEnv.USE_DEBUGPY === 'False' || !isDebugScript
-            ? settings.interpreter.slice(1).concat([SERVER_SCRIPT_PATH])
-            : settings.interpreter.slice(1).concat([DEBUG_SERVER_SCRIPT_PATH]);
-    traceInfo(`Server run command: ${[command, ...args].join(' ')}`);
-
-    const serverOptions: ServerOptions = {
-        command,
-        args,
-        options: { cwd, env: newEnv },
-        transport: getServerTransport(serverId, workspaceUri),
-    };
-
-    // Options to control the language client
-    const clientOptions: LanguageClientOptions = {
-        // Register the server for python documents
-        documentSelector: getDocumentSelector(),
-        outputChannel: outputChannel,
-        traceOutputChannel: outputChannel,
-        revealOutputChannelOn: RevealOutputChannelOn.Never,
-        initializationOptions,
-    };
-
-    return new LanguageClient(serverId, serverName, serverOptions, clientOptions);
+export function getServerCwd(settings: ISettings): string {
+    // ISettings is structurally compatible but lacks the index signature IBaseSettings requires
+    return _getServerCwd(settings as unknown as IBaseSettings);
 }
 
 let _disposables: Disposable[] = [];
+
 export async function restartServer(
     workspaceSetting: ISettings,
     serverId: string,
@@ -103,47 +31,27 @@ export async function restartServer(
     outputChannel: LogOutputChannel,
     oldLsClient?: LanguageClient,
 ): Promise<LanguageClient | undefined> {
-    if (oldLsClient) {
-        traceInfo(`Server: Stop requested`);
+    _disposables.forEach((d) => {
         try {
-            await oldLsClient.stop();
+            d.dispose();
         } catch (ex) {
-            traceError(`Server: Stop failed: ${ex}`);
+            traceError(`Failed to dispose: ${ex}`);
         }
-    }
-    _disposables.forEach((d) => d.dispose());
-    _disposables = [];
-    updateStatus(undefined, LanguageStatusSeverity.Information, true);
-
-    const newLSClient = await createServer(workspaceSetting, serverId, serverName, outputChannel, {
-        settings: await getExtensionSettings(serverId, true),
-        globalSettings: await getGlobalSettings(serverId, false),
     });
+    _disposables = [];
 
-    traceInfo(`Server: Start requested.`);
-    _disposables.push(
-        newLSClient.onDidChangeState((e) => {
-            switch (e.newState) {
-                case State.Stopped:
-                    traceVerbose(`Server State: Stopped`);
-                    break;
-                case State.Starting:
-                    traceVerbose(`Server State: Starting`);
-                    unregisterEmptyFormatter();
-                    break;
-                case State.Running:
-                    traceVerbose(`Server State: Running`);
-                    updateStatus(undefined, LanguageStatusSeverity.Information, false);
-                    break;
-            }
-        }),
+    const result = await _restartServer(
+        {
+            settings: workspaceSetting as unknown as IBaseSettings,
+            serverId,
+            serverName,
+            outputChannel,
+            toolConfig: BLACK_TOOL_CONFIG,
+            pythonProvider: getPythonProvider(),
+        },
+        oldLsClient as unknown as undefined,
     );
-    try {
-        await newLSClient.start();
-    } catch (ex) {
-        updateStatus(l10n.t('Server failed to start.'), LanguageStatusSeverity.Error);
-        traceError(`Server: Start failed: ${ex}`);
-    }
-    await newLSClient.setTrace(getLSClientTraceLevel(outputChannel.logLevel, env.logLevel));
-    return newLSClient;
+
+    _disposables = result.disposables;
+    return result.client as unknown as LanguageClient | undefined;
 }

--- a/src/test/python_tests/conftest.py
+++ b/src/test/python_tests/conftest.py
@@ -129,6 +129,12 @@ def setup_lsp_mocks():
         sys.path.insert(0, tool_dir)
         _INJECTED_PATH = tool_dir
 
+    # Also add bundled/libs so the shared vscode_common_python_lsp package
+    # is importable (installed there by nox install_bundled_libs).
+    libs_dir = str(pathlib.Path(__file__).parents[3] / "bundled" / "libs")
+    if libs_dir not in sys.path:
+        sys.path.insert(0, libs_dir)
+
     # -- Wire modules into sys.modules --------------------------------------
     # lsp_utils, lsp_jsonrpc, lsp_edit_utils, and lsp_io live in bundled/tool
     # and only use stdlib — let the real modules be imported so integration

--- a/src/test/python_tests/test_change_cwd.py
+++ b/src/test/python_tests/test_change_cwd.py
@@ -34,7 +34,7 @@ def test_change_cwd_permission_error_does_not_crash(caplog):
     original_cwd = os.getcwd()
     body_executed = False
 
-    with patch("lsp_utils.os.chdir", side_effect=PermissionError("Access denied")):
+    with patch("vscode_common_python_lsp.context.os.chdir", side_effect=PermissionError("Access denied")):
         with caplog.at_level(logging.WARNING):
             with lsp_utils.change_cwd("/restricted/path"):
                 body_executed = True
@@ -54,7 +54,7 @@ def test_change_cwd_oserror_does_not_crash(caplog):
     original_cwd = os.getcwd()
     body_executed = False
 
-    with patch("lsp_utils.os.chdir", side_effect=OSError("Some OS error")):
+    with patch("vscode_common_python_lsp.context.os.chdir", side_effect=OSError("Some OS error")):
         with caplog.at_level(logging.WARNING):
             with lsp_utils.change_cwd("/inaccessible"):
                 body_executed = True

--- a/src/test/python_tests/test_change_cwd.py
+++ b/src/test/python_tests/test_change_cwd.py
@@ -34,7 +34,10 @@ def test_change_cwd_permission_error_does_not_crash(caplog):
     original_cwd = os.getcwd()
     body_executed = False
 
-    with patch("vscode_common_python_lsp.context.os.chdir", side_effect=PermissionError("Access denied")):
+    with patch(
+        "vscode_common_python_lsp.context.os.chdir",
+        side_effect=PermissionError("Access denied"),
+    ):
         with caplog.at_level(logging.WARNING):
             with lsp_utils.change_cwd("/restricted/path"):
                 body_executed = True
@@ -54,7 +57,10 @@ def test_change_cwd_oserror_does_not_crash(caplog):
     original_cwd = os.getcwd()
     body_executed = False
 
-    with patch("vscode_common_python_lsp.context.os.chdir", side_effect=OSError("Some OS error")):
+    with patch(
+        "vscode_common_python_lsp.context.os.chdir",
+        side_effect=OSError("Some OS error"),
+    ):
         with caplog.at_level(logging.WARNING):
             with lsp_utils.change_cwd("/inaccessible"):
                 body_executed = True


### PR DESCRIPTION
## Summary

Wires the `vscode-common-python-lsp` shared package into the extension (Stage 1). This replaces duplicated utility code with thin wrappers that delegate to the shared package.

## Changes

- **Python**: Replace `lsp_utils.py` with thin wrapper importing from shared package
- **TypeScript**: Add `ToolConfig` to `constants.ts`, replace `server.ts` with shared package delegation
- **Dependencies**: Add `@vscode/common-python-lsp` (npm) and `vscode-common-python-lsp==0.3.0` (PyPI bundled)

## Result

- Zero behavioral changes
- All tests pass