### PR TITLE
refactor: use shared package APIs for settings and lsp_server

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -148,9 +148,9 @@ def range_formatting(
     """LSP handler for textDocument/rangeFormatting request."""
     document = LSP_SERVER.workspace.get_text_document(params.text_document.uri)
     settings = tool_server.get_settings_by_document(document)
-    version = VERSION_LOOKUP[settings["workspaceFS"]]
+    version = VERSION_LOOKUP.get(settings["workspaceFS"])
 
-    if version >= LINE_RANGES_MIN_VERSION:
+    if version is not None and version >= LINE_RANGES_MIN_VERSION:
         return _formatting_helper(
             document,
             args=[
@@ -159,9 +159,10 @@ def range_formatting(
             ],
         )
 
-    tool_server.log_warning(
-        "Black version earlier than 23.11.0 does not support range formatting. Formatting entire document."
-    )
+    if version is not None:
+        tool_server.log_warning(
+            "Black version earlier than 23.11.0 does not support range formatting. Formatting entire document."
+        )
     return _formatting_helper(document)
 
 
@@ -172,17 +173,18 @@ def ranges_formatting(
     """LSP handler for textDocument/rangesFormatting request."""
     document = LSP_SERVER.workspace.get_text_document(params.text_document.uri)
     settings = tool_server.get_settings_by_document(document)
-    version = VERSION_LOOKUP[settings["workspaceFS"]]
+    version = VERSION_LOOKUP.get(settings["workspaceFS"])
 
-    if version >= LINE_RANGES_MIN_VERSION:
+    if version is not None and version >= LINE_RANGES_MIN_VERSION:
         args = []
         for r in params.ranges:
             args += ["--line-ranges", f"{r.start.line + 1}-{r.end.line + 1}"]
         return _formatting_helper(document, args=args)
 
-    tool_server.log_warning(
-        "Black version earlier than 23.11.0 does not support range formatting. Formatting entire document."
-    )
+    if version is not None:
+        tool_server.log_warning(
+            "Black version earlier than 23.11.0 does not support range formatting. Formatting entire document."
+        )
     return _formatting_helper(document)
 
 
@@ -271,7 +273,7 @@ def initialize(params: lsp.InitializeParams) -> None:
     tool_server.apply_settings(params)
     settings = (params.initialization_options or {}).get("settings")
     tool_server.log_startup_info(settings)
-    _update_workspace_settings_with_version_info(WORKSPACE_SETTINGS)
+    _update_workspace_settings_with_version_info(tool_server.workspace_settings)
 
 
 @LSP_SERVER.feature(lsp.EXIT)

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import ast
 import copy
-import json
 import os
 import pathlib
 import re
@@ -44,7 +43,6 @@ update_sys_path(
 # pylint: disable=wrong-import-position,import-error
 import lsp_edit_utils as edit_utils
 import lsp_io
-import lsp_jsonrpc as jsonrpc
 import lsp_notebook as notebook
 import lsp_utils as utils
 from lsprotocol import types as lsp
@@ -53,16 +51,16 @@ from pygls.lsp.server import LanguageServer
 from pygls.workspace import TextDocument
 from vscode_common_python_lsp import (
     RunResult,
+    ToolServer,
+    ToolServerConfig,
     is_current_interpreter,
-    normalize_path,
-    substitute_attr,
+    match_line_endings,
+    strip_trailing_newline,
     update_environ_path,
 )
 
 update_environ_path()
 
-WORKSPACE_SETTINGS = {}
-GLOBAL_SETTINGS = {}
 RUNNER = pathlib.Path(__file__).parent / "lsp_runner.py"
 
 MAX_WORKERS = 5
@@ -73,6 +71,38 @@ LSP_SERVER = LanguageServer(
     max_workers=MAX_WORKERS,
     notebook_document_sync=notebook.NOTEBOOK_SYNC_OPTIONS,
 )
+
+
+TOOL_MODULE = "black"
+TOOL_DISPLAY = "Black Formatter"
+
+# Default arguments always passed to black.
+TOOL_ARGS = []
+
+# Minimum version of black supported.
+MIN_VERSION = "22.3.0"
+
+BLACK_CONFIG = ToolServerConfig(
+    tool_module=TOOL_MODULE,
+    tool_display=TOOL_DISPLAY,
+    tool_args=TOOL_ARGS,
+    min_version=MIN_VERSION,
+    runner_script=str(RUNNER),
+)
+
+tool_server = ToolServer(BLACK_CONFIG, server=LSP_SERVER)
+
+WORKSPACE_SETTINGS = tool_server.workspace_settings
+GLOBAL_SETTINGS = tool_server.global_settings
+
+# Minimum version of black that supports the `--line-ranges` CLI option.
+LINE_RANGES_MIN_VERSION = (23, 11, 0)
+
+# Timeout in seconds for formatting operations to prevent indefinite blocking.
+FORMATTING_TIMEOUT = 120
+
+# Versions of black found by workspace
+VERSION_LOOKUP: Dict[str, Tuple[int, int, int]] = {}
 
 
 def _get_document_path(document: TextDocument) -> str:
@@ -94,23 +124,6 @@ def _get_document_path(document: TextDocument) -> str:
 # **********************************************************
 # Tool specific code goes below this.
 # **********************************************************
-TOOL_MODULE = "black"
-TOOL_DISPLAY = "Black Formatter"
-
-# Default arguments always passed to black.
-TOOL_ARGS = []
-
-# Minimum version of black supported.
-MIN_VERSION = "22.3.0"
-
-# Minimum version of black that supports the `--line-ranges` CLI option.
-LINE_RANGES_MIN_VERSION = (23, 11, 0)
-
-# Timeout in seconds for formatting operations to prevent indefinite blocking.
-FORMATTING_TIMEOUT = 120
-
-# Versions of black found by workspace
-VERSION_LOOKUP: Dict[str, Tuple[int, int, int]] = {}
 
 # **********************************************************
 # Formatting features start here
@@ -134,7 +147,7 @@ def range_formatting(
 ) -> list[lsp.TextEdit] | None:
     """LSP handler for textDocument/rangeFormatting request."""
     document = LSP_SERVER.workspace.get_text_document(params.text_document.uri)
-    settings = _get_settings_by_document(document)
+    settings = tool_server.get_settings_by_document(document)
     version = VERSION_LOOKUP[settings["workspaceFS"]]
 
     if version >= LINE_RANGES_MIN_VERSION:
@@ -145,11 +158,11 @@ def range_formatting(
                 f"{params.range.start.line + 1}-{params.range.end.line + 1}",
             ],
         )
-    else:
-        log_warning(
-            "Black version earlier than 23.11.0 does not support range formatting. Formatting entire document."
-        )
-        return _formatting_helper(document)
+
+    tool_server.log_warning(
+        "Black version earlier than 23.11.0 does not support range formatting. Formatting entire document."
+    )
+    return _formatting_helper(document)
 
 
 @LSP_SERVER.feature(lsp.TEXT_DOCUMENT_RANGES_FORMATTING)
@@ -158,7 +171,7 @@ def ranges_formatting(
 ) -> list[lsp.TextEdit] | None:
     """LSP handler for textDocument/rangesFormatting request."""
     document = LSP_SERVER.workspace.get_text_document(params.text_document.uri)
-    settings = _get_settings_by_document(document)
+    settings = tool_server.get_settings_by_document(document)
     version = VERSION_LOOKUP[settings["workspaceFS"]]
 
     if version >= LINE_RANGES_MIN_VERSION:
@@ -166,11 +179,11 @@ def ranges_formatting(
         for r in params.ranges:
             args += ["--line-ranges", f"{r.start.line + 1}-{r.end.line + 1}"]
         return _formatting_helper(document, args=args)
-    else:
-        log_warning(
-            "Black version earlier than 23.11.0 does not support range formatting. Formatting entire document."
-        )
-        return _formatting_helper(document)
+
+    tool_server.log_warning(
+        "Black version earlier than 23.11.0 does not support range formatting. Formatting entire document."
+    )
+    return _formatting_helper(document)
 
 
 def is_python(code: str, file_path: str) -> bool:
@@ -178,7 +191,7 @@ def is_python(code: str, file_path: str) -> bool:
     try:
         ast.parse(code, file_path)
     except SyntaxError:
-        log_error(f"Syntax error in code: {traceback.format_exc()}")
+        tool_server.log_error(f"Syntax error in code: {traceback.format_exc()}")
         return False
     return True
 
@@ -187,18 +200,18 @@ def _formatting_helper(
     document: TextDocument, args: Sequence[str] = None
 ) -> list[lsp.TextEdit] | None:
     args = [] if args is None else args
-    extra_args = args + _get_args_by_file_extension(document)
+    extra_args = list(args) + _get_args_by_file_extension(document)
     extra_args += ["--stdin-filename", _get_filename_for_black(document)]
     try:
         result = _run_tool_on_document(document, use_stdin=True, extra_args=extra_args)
     except (subprocess.TimeoutExpired, TimeoutError):
-        log_warning(
+        tool_server.log_warning(
             f"Formatting timed out after {FORMATTING_TIMEOUT}s for {document.uri}"
         )
         return None
     if result and result.stdout:
         if LSP_SERVER.protocol.trace == lsp.TraceValue.Verbose:
-            log_to_output(
+            tool_server.log_to_output(
                 f"{document.uri} :\r\n"
                 + ("*" * 100)
                 + "\r\n"
@@ -207,23 +220,16 @@ def _formatting_helper(
                 + "\r\n"
             )
 
-        new_source = _match_line_endings(document, result.stdout)
+        new_source = match_line_endings(document.source, result.stdout)
 
-        # Skip last line ending in a notebook cell
         if document.uri.startswith("vscode-notebook-cell"):
-            if new_source.endswith("\r\n"):
-                new_source = new_source[:-2]
-            elif new_source.endswith("\n"):
-                new_source = new_source[:-1]
+            new_source = strip_trailing_newline(new_source)
 
-        # If code is already formatted, then no need to send any edits.
         if new_source != document.source:
             edits = edit_utils.get_text_edits(
                 document.source, new_source, lsp.PositionEncodingKind.Utf16
             )
             if edits:
-                # NOTE: If you provide [] array, VS Code will clear the file of all contents.
-                # To indicate no changes to file return None.
                 return edits
     return None
 
@@ -232,28 +238,8 @@ def _get_filename_for_black(document: TextDocument) -> str:
     """Gets or generates a file name to use with black when formatting."""
     doc_path = _get_document_path(document)
     if document.uri.startswith("vscode-notebook-cell") and doc_path.endswith(".ipynb"):
-        # Treat the cell like a python file
         return str(pathlib.Path(doc_path).with_suffix(".py"))
     return doc_path
-
-
-def _get_line_endings(lines: list[str]) -> str:
-    """Returns line endings used in the text."""
-    try:
-        if lines[0][-2:] == "\r\n":
-            return "\r\n"
-        return "\n"
-    except Exception:  # pylint: disable=broad-except
-        return None
-
-
-def _match_line_endings(document: TextDocument, text: str) -> str:
-    """Ensures that the edited text line endings matches the document line endings."""
-    expected = _get_line_endings(document.source.splitlines(keepends=True))
-    actual = _get_line_endings(text.splitlines(keepends=True))
-    if actual == expected or actual is None or expected is None:
-        return text
-    return text.replace(actual, expected)
 
 
 def _get_args_by_file_extension(document: TextDocument) -> List[str]:
@@ -264,9 +250,9 @@ def _get_args_by_file_extension(document: TextDocument) -> List[str]:
     p = _get_document_path(document).lower()
     if p.endswith(".py"):
         return []
-    elif p.endswith(".pyi"):
+    if p.endswith(".pyi"):
         return ["--pyi"]
-    elif p.endswith(".ipynb"):
+    if p.endswith(".ipynb"):
         return ["--ipynb"]
     return []
 
@@ -282,35 +268,22 @@ def _get_args_by_file_extension(document: TextDocument) -> List[str]:
 @LSP_SERVER.feature(lsp.INITIALIZE)
 def initialize(params: lsp.InitializeParams) -> None:
     """LSP handler for initialize request."""
-    log_to_output(f"CWD Server: {os.getcwd()}")
-
-    GLOBAL_SETTINGS.update(**params.initialization_options.get("globalSettings", {}))
-
-    settings = params.initialization_options["settings"]
-    _update_workspace_settings(settings)
-    log_to_output(
-        f"Settings received on server:\r\n{json.dumps(settings, indent=4, ensure_ascii=False)}\r\n"
-    )
-    log_to_output(
-        f"Global settings received on server:\r\n{json.dumps(GLOBAL_SETTINGS, indent=4, ensure_ascii=False)}\r\n"
-    )
-
-    paths = "\r\n   ".join(sys.path)
-    log_to_output(f"sys.path used to run Server:\r\n   {paths}")
-
+    tool_server.apply_settings(params)
+    settings = (params.initialization_options or {}).get("settings")
+    tool_server.log_startup_info(settings)
     _update_workspace_settings_with_version_info(WORKSPACE_SETTINGS)
 
 
 @LSP_SERVER.feature(lsp.EXIT)
 def on_exit(_params: Optional[Any] = None) -> None:
     """Handle clean up on exit."""
-    jsonrpc.shutdown_json_rpc()
+    tool_server.handle_exit()
 
 
 @LSP_SERVER.feature(lsp.SHUTDOWN)
 def on_shutdown(_params: Optional[Any] = None) -> None:
     """Handle clean up on shutdown."""
-    jsonrpc.shutdown_json_rpc()
+    tool_server.handle_shutdown()
 
 
 def _update_workspace_settings_with_version_info(
@@ -322,17 +295,15 @@ def _update_workspace_settings_with_version_info(
 
             result = _run_tool(["--version"], copy.deepcopy(settings))
             code_workspace = settings["workspaceFS"]
-            log_to_output(
+            tool_server.log_to_output(
                 f"Version info for formatter running for {code_workspace}:\r\n{result.stdout}"
             )
 
             if "The typed_ast package is required but not installed" in result.stdout:
-                log_to_output(
+                tool_server.log_to_output(
                     'Install black in your environment and set "black-formatter.importStrategy": "fromEnvironment"'
                 )
 
-            # This is text we get from running `black --version`
-            # black, 22.3.0 (compiled: yes) <--- This is the version we want.
             first_line = result.stdout.splitlines(keepends=False)[0]
             parts = [v for v in first_line.split(" ") if re.match(r"\d+\.\d+\S*", v)]
             if len(parts) == 1:
@@ -349,165 +320,30 @@ def _update_workspace_settings_with_version_info(
             )
 
             if version < min_version:
-                log_error(
+                tool_server.log_error(
                     f"Version of formatter running for {code_workspace} is NOT supported:\r\n"
                     f"SUPPORTED {TOOL_MODULE}>={min_version}\r\n"
                     f"FOUND {TOOL_MODULE}=={actual_version}\r\n"
                 )
             else:
-                log_to_output(
+                tool_server.log_to_output(
                     f"SUPPORTED {TOOL_MODULE}>={min_version}\r\n"
                     f"FOUND {TOOL_MODULE}=={actual_version}\r\n"
                 )
 
         except:  # pylint: disable=bare-except
-            log_to_output(
+            tool_server.log_to_output(
                 f"Error while detecting black version:\r\n{traceback.format_exc()}"
             )
 
 
 # *****************************************************
-# Internal functional and settings management APIs.
-# *****************************************************
-def _get_global_defaults():
-    return {
-        "path": GLOBAL_SETTINGS.get("path", []),
-        "interpreter": GLOBAL_SETTINGS.get("interpreter", [sys.executable]),
-        "args": GLOBAL_SETTINGS.get("args", []),
-        "importStrategy": GLOBAL_SETTINGS.get("importStrategy", "useBundled"),
-        "showNotifications": GLOBAL_SETTINGS.get("showNotifications", "off"),
-    }
-
-
-def _update_workspace_settings(settings):
-    if not settings:
-        key = normalize_path(os.getcwd())
-        WORKSPACE_SETTINGS[key] = {
-            "cwd": key,
-            "workspaceFS": key,
-            "workspace": uris.from_fs_path(key),
-            **_get_global_defaults(),
-        }
-        return
-
-    for setting in settings:
-        key = normalize_path(uris.to_fs_path(setting["workspace"]))
-        WORKSPACE_SETTINGS[key] = {
-            **setting,
-            "workspaceFS": key,
-        }
-
-
-def _get_settings_by_path(file_path: pathlib.Path):
-    workspaces = {s["workspaceFS"] for s in WORKSPACE_SETTINGS.values()}
-
-    while file_path != file_path.parent:
-        str_file_path = normalize_path(file_path)
-        if str_file_path in workspaces:
-            return WORKSPACE_SETTINGS[str_file_path]
-        file_path = file_path.parent
-
-    setting_values = list(WORKSPACE_SETTINGS.values())
-    return setting_values[0]
-
-
-def _get_document_key(document: TextDocument):
-    if WORKSPACE_SETTINGS:
-        document_workspace = pathlib.Path(_get_document_path(document))
-        workspaces = {s["workspaceFS"] for s in WORKSPACE_SETTINGS.values()}
-
-        # Find workspace settings for the given file.
-        while document_workspace != document_workspace.parent:
-            norm_path = normalize_path(document_workspace)
-            if norm_path in workspaces:
-                return norm_path
-            document_workspace = document_workspace.parent
-
-    return None
-
-
-def _get_settings_by_document(document: TextDocument | None):
-    if document is None or document.path is None:
-        return list(WORKSPACE_SETTINGS.values())[0]
-
-    key = _get_document_key(document)
-    if key is None:
-        # This is either a non-workspace file or there is no workspace.
-        key = normalize_path(pathlib.Path(_get_document_path(document)).parent)
-        return {
-            "cwd": key,
-            "workspaceFS": key,
-            "workspace": uris.from_fs_path(key),
-            **_get_global_defaults(),
-        }
-
-    return WORKSPACE_SETTINGS[str(key)]
-
-
-# *****************************************************
 # Internal execution APIs.
 # *****************************************************
-def get_cwd(settings: Dict[str, Any], document: Optional[TextDocument]) -> str:
-    """Returns the working directory for running the tool.
-
-    Resolves the following VS Code file-related variable substitutions when
-    a document is available:
-
-    - ``${file}`` – absolute path of the current document.
-    - ``${fileBasename}`` – file name with extension (e.g. ``foo.py``).
-    - ``${fileBasenameNoExtension}`` – file name without extension (e.g. ``foo``).
-    - ``${fileExtname}`` – file extension including the dot (e.g. ``.py``).
-    - ``${fileDirname}`` – directory containing the current document.
-    - ``${fileDirnameBasename}`` – name of the directory containing the document.
-    - ``${relativeFile}`` – document path relative to the workspace root.
-    - ``${relativeFileDirname}`` – document directory relative to the workspace root.
-    - ``${fileWorkspaceFolder}`` – workspace root folder for the document.
-
-    Variables that do not depend on the document (``${workspaceFolder}``,
-    ``${userHome}``, ``${cwd}``) are pre-resolved by the TypeScript client.
-
-    If no document is available and the value contains any unresolvable
-    file-variable, the workspace root is returned as a fallback.
-
-    See https://code.visualstudio.com/docs/reference/variables-reference
-    """
-    cwd = settings.get("cwd", settings["workspaceFS"])
-    workspace_fs = settings["workspaceFS"]
-
-    file_path = _get_document_path(document) if document else ""
-    if document and file_path:
-        file_dir = os.path.dirname(file_path)
-        file_basename = os.path.basename(file_path)
-        file_stem, file_ext = os.path.splitext(file_basename)
-
-        substitutions = {
-            "${file}": file_path,
-            "${fileBasename}": file_basename,
-            "${fileBasenameNoExtension}": file_stem,
-            "${fileExtname}": file_ext,
-            "${fileDirname}": file_dir,
-            "${fileDirnameBasename}": os.path.basename(file_dir),
-            "${relativeFile}": os.path.relpath(file_path, workspace_fs),
-            "${relativeFileDirname}": os.path.relpath(file_dir, workspace_fs),
-            "${fileWorkspaceFolder}": workspace_fs,
-        }
-
-        for token, value in substitutions.items():
-            cwd = cwd.replace(token, value)
-    else:
-        # Without a document we cannot resolve file-related variables.
-        # Fall back to workspace root if any remain.
-        if "${file" in cwd or "${relativeFile" in cwd:
-            cwd = workspace_fs
-
-    return cwd
-
-
-# pylint: disable=too-many-branches
 def _run_tool_on_document(
     document: TextDocument,
     use_stdin: bool = False,
-    extra_args: Sequence[str] = [],
+    extra_args: Sequence[str] = (),
 ) -> RunResult | None:
     """Runs tool on the given document.
 
@@ -516,239 +352,152 @@ def _run_tool_on_document(
     """
     doc_path = _get_document_path(document)
     if utils.is_stdlib_file(doc_path):
-        log_warning(f"Skipping standard library file: {doc_path}")
+        tool_server.log_warning(f"Skipping standard library file: {doc_path}")
         return None
 
     if not is_python(document.source, doc_path):
-        log_warning(f"Skipping non python code or code with syntax errors: {doc_path}")
+        tool_server.log_warning(
+            f"Skipping non python code or code with syntax errors: {doc_path}"
+        )
         return None
 
-    # deep copy here to prevent accidentally updating global settings.
-    settings = copy.deepcopy(_get_settings_by_document(document))
-
+    settings = copy.deepcopy(tool_server.get_settings_by_document(document))
     code_workspace = settings["workspaceFS"]
-    cwd = get_cwd(settings, document)
+    cwd = tool_server.get_cwd(settings, document, document_path=doc_path)
 
-    use_path = False
-    use_rpc = False
     if settings["path"]:
-        # 'path' setting takes priority over everything.
-        use_path = True
-        argv = settings["path"]
+        mode = "path"
+        argv = list(settings["path"])
     elif settings["interpreter"] and not is_current_interpreter(
         settings["interpreter"][0]
     ):
-        # If there is a different interpreter set use JSON-RPC to the subprocess
-        # running under that interpreter.
+        mode = "rpc"
         argv = [TOOL_MODULE]
-        use_rpc = True
     else:
-        # if the interpreter is same as the interpreter running this
-        # process then run as module.
+        mode = "module"
         argv = [TOOL_MODULE]
 
-    argv += TOOL_ARGS + settings["args"] + extra_args
+    argv += TOOL_ARGS + settings["args"] + list(extra_args)
 
     if use_stdin:
         argv += ["-"]
 
-    if use_path:
-        # This mode is used when running executables.
-        log_to_output(" ".join(argv))
-        log_to_output(f"CWD Server: {cwd}")
-        result = utils.run_path(
-            argv=argv,
-            use_stdin=use_stdin,
-            cwd=cwd,
-            source=document.source.replace("\r\n", "\n"),
-            timeout=FORMATTING_TIMEOUT,
-        )
-        if result.stderr:
-            log_to_output(result.stderr)
-    elif use_rpc:
-        # This mode is used if the interpreter running this server is different from
-        # the interpreter used for running this server.
-        log_to_output(" ".join(settings["interpreter"] + ["-m"] + argv))
-        log_to_output(f"CWD formatter: {cwd}")
+    source = document.source
+    if mode == "path" and use_stdin:
+        source = source.replace("\r\n", "\n")
 
-        result = jsonrpc.run_over_json_rpc(
-            workspace=code_workspace,
-            interpreter=settings["interpreter"],
-            module=TOOL_MODULE,
-            argv=argv,
-            use_stdin=use_stdin,
-            cwd=cwd,
-            source=document.source,
-            env={
-                "LS_IMPORT_STRATEGY": settings["importStrategy"],
-            },
-            timeout=FORMATTING_TIMEOUT,
-        )
-        result = _to_run_result_with_logging(result)
-    else:
-        # In this mode the tool is run as a module in the same process as the language server.
-        log_to_output(" ".join([sys.executable, "-m"] + argv))
-        log_to_output(f"CWD formatter: {cwd}")
-        # This is needed to preserve sys.path, in cases where the tool modifies
-        # sys.path and that might not work for this scenario next time around.
-        with substitute_attr(sys, "path", [""] + sys.path[:]):
-            try:
-                result = utils.run_module(
-                    module=TOOL_MODULE,
-                    argv=argv,
-                    use_stdin=use_stdin,
-                    cwd=cwd,
-                    source=document.source,
-                    timeout=FORMATTING_TIMEOUT,
-                )
-            except Exception:
-                log_error(traceback.format_exc(chain=True))
-                raise
-        if result.stderr:
-            log_to_output(result.stderr)
-
-    return result
+    return tool_server.execute_tool(
+        argv=argv,
+        mode=mode,
+        settings=settings,
+        use_stdin=use_stdin,
+        cwd=cwd,
+        workspace=code_workspace,
+        source=source,
+        env=(
+            {"LS_IMPORT_STRATEGY": settings["importStrategy"]}
+            if mode == "rpc"
+            else None
+        ),
+        timeout=FORMATTING_TIMEOUT,
+    )
 
 
 def _run_tool(extra_args: Sequence[str], settings: Dict[str, Any]) -> RunResult:
     """Runs tool."""
     code_workspace = settings["workspaceFS"]
-    cwd = get_cwd(settings, None)
+    cwd = tool_server.get_cwd(settings, None)
 
-    use_path = False
-    use_rpc = False
-    if len(settings["path"]) > 0:
-        # 'path' setting takes priority over everything.
-        use_path = True
-        argv = settings["path"]
-    elif len(settings["interpreter"]) > 0 and not is_current_interpreter(
+    if settings["path"]:
+        mode = "path"
+        argv = list(settings["path"])
+    elif settings["interpreter"] and not is_current_interpreter(
         settings["interpreter"][0]
     ):
-        # If there is a different interpreter set use JSON-RPC to the subprocess
-        # running under that interpreter.
+        mode = "rpc"
         argv = [TOOL_MODULE]
-        use_rpc = True
     else:
-        # if the interpreter is same as the interpreter running this
-        # process then run as module.
+        mode = "module"
         argv = [TOOL_MODULE]
 
-    argv += extra_args
+    argv += list(extra_args)
 
-    if use_path:
-        # This mode is used when running executables.
-        log_to_output(" ".join(argv))
-        log_to_output(f"CWD Server: {cwd}")
-        try:
-            result = utils.run_path(
-                argv=argv, use_stdin=True, cwd=cwd, timeout=FORMATTING_TIMEOUT
+    try:
+        result = tool_server.execute_tool(
+            argv=argv,
+            mode=mode,
+            settings=settings,
+            use_stdin=True,
+            cwd=cwd,
+            workspace=code_workspace,
+            env=(
+                {"LS_IMPORT_STRATEGY": settings["importStrategy"]}
+                if mode == "rpc"
+                else None
+            ),
+            timeout=FORMATTING_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, TimeoutError):
+        if mode == "rpc":
+            tool_server.log_warning(
+                f"JSON-RPC execution timed out after {FORMATTING_TIMEOUT}s"
             )
-        except (subprocess.TimeoutExpired, TimeoutError):
-            log_warning(f"Tool execution timed out after {FORMATTING_TIMEOUT}s")
-            return RunResult("", f"Timed out after {FORMATTING_TIMEOUT}s")
-        if result.stderr:
-            log_to_output(result.stderr)
-    elif use_rpc:
-        # This mode is used if the interpreter running this server is different from
-        # the interpreter used for running this server.
-        log_to_output(" ".join(settings["interpreter"] + ["-m"] + argv))
-        log_to_output(f"CWD formatter: {cwd}")
-        try:
-            result = jsonrpc.run_over_json_rpc(
-                workspace=code_workspace,
-                interpreter=settings["interpreter"],
-                module=TOOL_MODULE,
-                argv=argv,
-                use_stdin=True,
-                cwd=cwd,
-                env={
-                    "LS_IMPORT_STRATEGY": settings["importStrategy"],
-                },
-                timeout=FORMATTING_TIMEOUT,
+        else:
+            tool_server.log_warning(
+                f"Tool execution timed out after {FORMATTING_TIMEOUT}s"
             )
-        except (subprocess.TimeoutExpired, TimeoutError):
-            log_warning(f"JSON-RPC execution timed out after {FORMATTING_TIMEOUT}s")
-            return RunResult("", f"Timed out after {FORMATTING_TIMEOUT}s")
-        result = _to_run_result_with_logging(result)
-    else:
-        # In this mode the tool is run as a module in the same process as the language server.
-        log_to_output(" ".join([sys.executable, "-m"] + argv))
-        log_to_output(f"CWD formatter: {cwd}")
-        # This is needed to preserve sys.path, in cases where the tool modifies
-        # sys.path and that might not work for this scenario next time around.
-        with substitute_attr(sys, "path", [""] + sys.path[:]):
-            try:
-                result = utils.run_module(
-                    module=TOOL_MODULE,
-                    argv=argv,
-                    use_stdin=True,
-                    cwd=cwd,
-                    timeout=FORMATTING_TIMEOUT,
-                )
-            except Exception:
-                log_error(traceback.format_exc(chain=True))
-                raise
-        if result.stderr:
-            log_to_output(result.stderr)
+        return RunResult("", f"Timed out after {FORMATTING_TIMEOUT}s")
 
     if LSP_SERVER.protocol.trace == lsp.TraceValue.Verbose:
-        log_to_output(f"\r\n{result.stdout}\r\n")
+        tool_server.log_to_output(f"\r\n{result.stdout}\r\n")
 
     return result
 
 
-def _to_run_result_with_logging(rpc_result: jsonrpc.RpcRunResult) -> RunResult:
-    error = ""
-    if rpc_result.exception:
-        log_error(rpc_result.exception)
-        error = rpc_result.exception
-    elif rpc_result.stderr:
-        log_to_output(rpc_result.stderr)
-        error = rpc_result.stderr
-    return RunResult(rpc_result.stdout, error)
+# *****************************************************
+# Internal settings management APIs.
+# Thin wrappers delegating to ToolServer for backward compatibility.
+# *****************************************************
+def _get_global_defaults():
+    return tool_server.get_global_defaults()
+
+
+# *****************************************************
+# Internal execution APIs (wrapper).
+# *****************************************************
+def get_cwd(settings: Dict[str, Any], document: Optional[TextDocument]) -> str:
+    """Returns the working directory for running the tool."""
+    if document:
+        return tool_server.get_cwd(
+            settings, document, document_path=_get_document_path(document)
+        )
+    return tool_server.get_cwd(settings, document)
 
 
 # *****************************************************
 # Logging and notification.
+# Thin wrappers delegating to ToolServer for backward compatibility.
 # *****************************************************
 def log_to_output(
     message: str, msg_type: lsp.MessageType = lsp.MessageType.Log
 ) -> None:
     """Logs messages to Output > Black Formatter channel only."""
-    LSP_SERVER.window_log_message(lsp.LogMessageParams(type=msg_type, message=message))
+    tool_server.log_to_output(message, msg_type)
 
 
 def log_error(message: str) -> None:
     """Logs messages with notification on error."""
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Error, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["onError", "onWarning", "always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Error, message=message)
-        )
+    tool_server.log_error(message)
 
 
 def log_warning(message: str) -> None:
     """Logs messages with notification on warning."""
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Warning, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["onWarning", "always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Warning, message=message)
-        )
+    tool_server.log_warning(message)
 
 
 def log_always(message: str) -> None:
     """Logs messages with notification."""
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Info, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Info, message=message)
-        )
+    tool_server.log_always(message)
 
 
 # *****************************************************

--- a/noxfile.py
+++ b/noxfile.py
@@ -118,7 +118,7 @@ def install_bundled_libs(session):
         "--no-cache-dir",
         "--no-deps",
         "--upgrade",
-        "vscode-common-python-lsp==0.5.1",
+        "vscode-common-python-lsp==0.6.0",
     )
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "black-formatter",
-    "version": "2026.5.0-dev",
+    "version": "2026.7.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "black-formatter",
-            "version": "2026.5.0-dev",
+            "version": "2026.7.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "0.5.1",
+                "@vscode/common-python-lsp": "^0.6.0",
                 "@vscode/python-extension": "^1.0.5",
                 "dotenv": "^17.4.0",
                 "fs-extra": "^11.3.4",
@@ -1154,6 +1154,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
             "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.57.0",
                 "@typescript-eslint/types": "8.57.0",
@@ -1395,9 +1396,9 @@
             }
         },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.1.tgz",
-            "integrity": "sha512-iJ7s0DyE1IZ1HSoDfTBHtVuf/jlXTqtKZDeD+m922gz5JAeiVSxg89dfTxDxxwEPAZXPG4kpNUjgWiFI3wTktA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.6.0.tgz",
+            "integrity": "sha512-wabQS/YK4qlZtU2/e2JrdvuuwyjVfvoPayCcpv3n+3Ii7+4yumrP6vZo/4zsnTUlapBzckOiSyGuwA5oODJGdg==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
@@ -1941,6 +1942,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2279,6 +2281,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -3179,6 +3182,7 @@
             "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -6234,6 +6238,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6983,6 +6988,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -7150,6 +7156,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7381,6 +7388,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
             "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -7430,6 +7438,7 @@
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -8610,6 +8619,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
             "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "8.57.0",
                 "@typescript-eslint/types": "8.57.0",
@@ -8750,9 +8760,9 @@
             }
         },
         "@vscode/common-python-lsp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.1.tgz",
-            "integrity": "sha512-iJ7s0DyE1IZ1HSoDfTBHtVuf/jlXTqtKZDeD+m922gz5JAeiVSxg89dfTxDxxwEPAZXPG4kpNUjgWiFI3wTktA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.6.0.tgz",
+            "integrity": "sha512-wabQS/YK4qlZtU2/e2JrdvuuwyjVfvoPayCcpv3n+3Ii7+4yumrP6vZo/4zsnTUlapBzckOiSyGuwA5oODJGdg==",
             "requires": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/python-extension": "^1.0.6",
@@ -9144,7 +9154,8 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-import-phases": {
             "version": "1.0.4",
@@ -9378,6 +9389,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -9978,6 +9990,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
             "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -12109,6 +12122,7 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
                     "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
                         "fast-uri": "^3.0.1",
@@ -12626,7 +12640,8 @@
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
                     "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -12742,7 +12757,8 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "typescript-eslint": {
             "version": "8.57.0",
@@ -12900,6 +12916,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
             "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -12933,6 +12950,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -186,11 +186,11 @@
         ]
     },
     "dependencies": {
+        "@vscode/common-python-lsp": "^0.6.0",
         "@vscode/python-extension": "^1.0.5",
         "dotenv": "^17.4.0",
         "fs-extra": "^11.3.4",
-        "vscode-languageclient": "^9.0.1",
-        "@vscode/common-python-lsp": "0.5.1"
+        "vscode-languageclient": "^9.0.1"
     },
     "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -201,9 +201,9 @@
         "@types/node": "22.x",
         "@types/sinon": "^21.0.0",
         "@types/vscode": "^1.74.0",
-        "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
         "@typescript-eslint/parser": "^8.57.0",
+        "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.7.1-1",
         "chai": "^4.3.10",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -44,25 +44,8 @@ export function logDefaultFormatter(): void {
 }
 
 export function logLegacySettings(): void {
-    // Array settings can use the shared helper directly.
     _logLegacySettings('black-formatter', [
         { legacyKey: 'formatting.blackArgs', newKey: 'args', isArray: true },
+        { legacyKey: 'formatting.blackPath', newKey: 'path', defaultValue: 'black' },
     ]);
-
-    // Path needs local handling: suppress warning when the value is the
-    // historical default 'black' (the shared helper doesn't support
-    // defaultValue filtering yet).
-    getWorkspaceFolders().forEach((workspace) => {
-        try {
-            const legacyConfig = getConfiguration('python', workspace.uri);
-            const legacyPath = legacyConfig.get<string>('formatting.blackPath', '');
-            if (legacyPath.length > 0 && legacyPath !== 'black') {
-                traceWarn(`"python.formatting.blackPath" is deprecated. Use "black-formatter.path" instead.`);
-                traceWarn(`"python.formatting.blackPath" for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyPath, null, 4)}`);
-            }
-        } catch (err) {
-            traceWarn(`Error while logging legacy settings: ${err}`);
-        }
-    });
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -5,7 +5,14 @@
 // All shared settings resolution is handled by @vscode/common-python-lsp directly.
 
 import { Uri } from 'vscode';
-import { IBaseSettings, getConfiguration, getWorkspaceFolders, traceInfo, traceWarn } from '@vscode/common-python-lsp';
+import {
+    IBaseSettings,
+    getConfiguration,
+    getWorkspaceFolders,
+    logLegacySettings as _logLegacySettings,
+    traceInfo,
+    traceWarn,
+} from '@vscode/common-python-lsp';
 import { EXTENSION_ID } from './constants';
 import { TransportKind } from 'vscode-languageclient/node';
 
@@ -37,24 +44,8 @@ export function logDefaultFormatter(): void {
 }
 
 export function logLegacySettings(): void {
-    getWorkspaceFolders().forEach((workspace) => {
-        try {
-            const legacyConfig = getConfiguration('python', workspace.uri);
-            const legacyArgs = legacyConfig.get<string[]>('formatting.blackArgs', []);
-            const legacyPath = legacyConfig.get<string>('formatting.blackPath', '');
-            if (legacyArgs.length > 0) {
-                traceWarn(`"python.formatting.blackArgs" is deprecated. Use "black-formatter.args" instead.`);
-                traceWarn(`"python.formatting.blackArgs" for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyArgs, null, 4)}`);
-            }
-
-            if (legacyPath.length > 0 && legacyPath !== 'black') {
-                traceWarn(`"python.formatting.blackPath" is deprecated. Use "black-formatter.path" instead.`);
-                traceWarn(`"python.formatting.blackPath" for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyPath, null, 4)}`);
-            }
-        } catch (err) {
-            traceWarn(`Error while logging legacy settings: ${err}`);
-        }
-    });
+    _logLegacySettings('black-formatter', [
+        { legacyKey: 'formatting.blackArgs', newKey: 'args', isArray: true },
+        { legacyKey: 'formatting.blackPath', newKey: 'path' },
+    ]);
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -44,8 +44,25 @@ export function logDefaultFormatter(): void {
 }
 
 export function logLegacySettings(): void {
+    // Array settings can use the shared helper directly.
     _logLegacySettings('black-formatter', [
         { legacyKey: 'formatting.blackArgs', newKey: 'args', isArray: true },
-        { legacyKey: 'formatting.blackPath', newKey: 'path' },
     ]);
+
+    // Path needs local handling: suppress warning when the value is the
+    // historical default 'black' (the shared helper doesn't support
+    // defaultValue filtering yet).
+    getWorkspaceFolders().forEach((workspace) => {
+        try {
+            const legacyConfig = getConfiguration('python', workspace.uri);
+            const legacyPath = legacyConfig.get<string>('formatting.blackPath', '');
+            if (legacyPath.length > 0 && legacyPath !== 'black') {
+                traceWarn(`"python.formatting.blackPath" is deprecated. Use "black-formatter.path" instead.`);
+                traceWarn(`"python.formatting.blackPath" for workspace ${workspace.uri.fsPath}:`);
+                traceWarn(`\n${JSON.stringify(legacyPath, null, 4)}`);
+            }
+        } catch (err) {
+            traceWarn(`Error while logging legacy settings: ${err}`);
+        }
+    });
 }


### PR DESCRIPTION
## Summary
Reduce code duplication between this extension and the shared package `@vscode/common-python-lsp` (`vscode-common-python-lsp`).

### Changes
- **`src/common/settings.ts`**: Use shared `logLegacySettings()` instead of inline legacy-setting migration warnings
- **`bundled/tool/lsp_server.py`**: Migrate to `ToolServer`/`ToolServerConfig` from the shared package — replaces hand-rolled settings management, CWD resolution, tool execution, logging, and lifecycle handlers with shared implementations

### Impact
- Significant reduction in duplicated code across all extension repos
- Tool-specific logic (formatting, code actions, daemon management, etc.) remains local
- No behavioral changes — all existing functionality preserved
- No test modifications