### PR TITLE
bump @vscode/common-python-lsp, to incorporate upstream changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "black-formatter",
-    "version": "2026.5.0-dev",
+    "version": "2026.7.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "black-formatter",
-            "version": "2026.5.0-dev",
+            "version": "2026.7.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "0.5.1",
+                "@vscode/common-python-lsp": "^0.5.2",
                 "@vscode/python-extension": "^1.0.5",
                 "dotenv": "^17.4.0",
                 "fs-extra": "^11.3.4",
@@ -1395,9 +1395,9 @@
             }
         },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.1.tgz",
-            "integrity": "sha512-iJ7s0DyE1IZ1HSoDfTBHtVuf/jlXTqtKZDeD+m922gz5JAeiVSxg89dfTxDxxwEPAZXPG4kpNUjgWiFI3wTktA==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.2.tgz",
+            "integrity": "sha512-hc5C6hQfiKmgo4fTNrSdTQ6bz2pVeO5PnPYaA7Izdjq0A9XDBamJPIajgpPduhwOVI7r0/DPbKdJ7+OtYEC4Bw==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
@@ -8750,9 +8750,9 @@
             }
         },
         "@vscode/common-python-lsp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.1.tgz",
-            "integrity": "sha512-iJ7s0DyE1IZ1HSoDfTBHtVuf/jlXTqtKZDeD+m922gz5JAeiVSxg89dfTxDxxwEPAZXPG4kpNUjgWiFI3wTktA==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.2.tgz",
+            "integrity": "sha512-hc5C6hQfiKmgo4fTNrSdTQ6bz2pVeO5PnPYaA7Izdjq0A9XDBamJPIajgpPduhwOVI7r0/DPbKdJ7+OtYEC4Bw==",
             "requires": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/python-extension": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
         "dotenv": "^17.4.0",
         "fs-extra": "^11.3.4",
         "vscode-languageclient": "^9.0.1",
-        "@vscode/common-python-lsp": "0.5.1"
+        "@vscode/common-python-lsp": "0.5.2"
     },
     "devDependencies": {
         "@eslint/js": "^9.33.0",


### PR DESCRIPTION
This PR updates @vscode/common-python-lsp from 0.5.1 to 0.5.2 and refreshes the lockfile to pull in the latest upstream changes. It is a dependency-only bump intended to incorporate the upstream fix from the earlier bug report in #735  , with no direct functional changes in the extension code.