### PR TITLE
Don't open issues on agentic workflow no-op runs

### DIFF
--- a/.github/workflows/check-python-versions.lock.yml
+++ b/.github/workflows/check-python-versions.lock.yml
@@ -23,7 +23,7 @@
 #
 # Annual check of the latest supported Python versions from peps.python.org. Creates a PR to add newly released versions and remove end-of-life versions from CI workflows, actions, Azure Pipelines, and source code.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"3f488bcea73ddbb890344cfa917bef7faa6924c2282f5a573b92d34236ec5e61","compiler_version":"v0.51.6"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"94ea0deb63648fc0ade7b93a5fb4815ad5fbc376c784f26a15db11ea38ea3087","compiler_version":"v0.51.6"}
 
 name: 'Annual Python Version Update'
 'on':
@@ -977,7 +977,7 @@ jobs:
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: 'true'
+          GH_AW_NOOP_REPORT_AS_ISSUE: 'false'
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check-python-versions.md
+++ b/.github/workflows/check-python-versions.md
@@ -27,6 +27,7 @@ safe-outputs:
     draft: true
   noop:
     max: 1
+    report-as-issue: false
 ---
 
 # Annual Python Version Update

--- a/.github/workflows/extension-template-sync.lock.yml
+++ b/.github/workflows/extension-template-sync.lock.yml
@@ -23,7 +23,7 @@
 #
 # Scheduled and on-demand check to detect unsynced changes from the upstream microsoft/vscode-python-tools-extension-template. Compares recent template PRs against this repo's files and opens an issue for each PR whose changes are not yet present.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"86fb3e2da6558db63304778d0efb2b96d848b28f23d9967640c5fdb6095f0a66","compiler_version":"v0.51.6"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"6ee45cb8ae37efb989a43099b8a4738f90b07a406d1f7f9b96efbd36dcdfc4d3","compiler_version":"v0.51.6"}
 
 name: 'Extension Template Sync'
 'on':
@@ -993,7 +993,7 @@ jobs:
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: 'true'
+          GH_AW_NOOP_REPORT_AS_ISSUE: 'false'
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/extension-template-sync.md
+++ b/.github/workflows/extension-template-sync.md
@@ -21,6 +21,8 @@ network:
 safe-outputs:
   create-issue:
     max: 10
+  noop:
+    report-as-issue: false
 steps:
 - name: Checkout repository
   uses: actions/checkout@v5

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -23,7 +23,7 @@
 #
 # When a new issue is opened — or when a maintainer comments `/triage-issue` on an existing issue — analyze its root cause, check whether the same issue could affect other extensions built from the microsoft/vscode-python-tools-extension-template or originate from the microsoft/vscode-common-python-lsp shared package, and look for related open issues on the upstream Black repository (psf/black). If applicable, suggest an upstream fix and surface relevant Black issues to the reporter.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"914bc4c51543ca1422674d463880bcabba92c5da9433b146c9412fceaa145e1e","compiler_version":"v0.51.6"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"866b19feda85875d1ff44e91a44271bc8794a100bc70ddc421c81e5dd9bfcb5a","compiler_version":"v0.51.6"}
 
 name: 'Issue Triage'
 'on':
@@ -981,7 +981,7 @@ jobs:
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: 'true'
+          GH_AW_NOOP_REPORT_AS_ISSUE: 'false'
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -26,6 +26,8 @@ safe-outputs:
     run-started: "⏳ **Triage Issue Agent**: I will analyze this issue and determine if related issues exist in this repo, the upstream Python tool, or similar extensions. This may take a couple of minutes."
   add-comment:
     max: 1
+  noop:
+    report-as-issue: false
 steps:
 - name: Checkout repository
   uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
Agentic workflows (gh-aw) currently open a GitHub issue whenever a run is a **no-op** (the agent has nothing to do). This adds `safe-outputs.noop.report-as-issue: false` to all three agentic workflows so a no-op is logged instead of filing an issue.

## Changes
For `check-python-versions`, `extension-template-sync`, and `issue-triage`:
- `.md`: add `noop.report-as-issue: false` under `safe-outputs`.
- `.lock.yml`: `GH_AW_NOOP_REPORT_AS_ISSUE` flips `'true'` → `'false'` (+ frontmatter hash). No other behavior changes.

Generated with `gh aw compile` (v0.51.6); lock diffs kept minimal.