### PR TITLE
narrow _update_workspace_settings_with_version_info except clause to specific exception types

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -373,7 +373,7 @@ def _update_workspace_settings_with_version_info(
                     f"FOUND {TOOL_MODULE}=={actual_version}\r\n"
                 )
 
-        except:  # pylint: disable=bare-except
+        except (ImportError, OSError, subprocess.SubprocessError, ValueError, IndexError, AttributeError):
             log_to_output(
                 f"Error while detecting black version:\r\n{traceback.format_exc()}"
             )


### PR DESCRIPTION
The bare `except:` clause in `_update_workspace_settings_with_version_info` (bundled/tool/lsp_server.py:378) was catching everything including `SystemExit` and `KeyboardInterrupt`. Replaced it with a tuple of the specific exception types that the function body can actually raise: `ImportError` (for the in-line `from packaging.version import parse as parse_version`), `OSError`/`subprocess.SubprocessError` (for the underlying `_run_tool` subprocess), `ValueError` and `IndexError` (for the `.stdout.splitlines(...)[0]` and version-string parsing), and `AttributeError` (for the `result.stdout` access when the subprocess produces no output). The `log_to_output(...)` debug behavior is preserved on all caught paths.