### PR TITLE
narrow _monitor_process except to KeyError

### DIFF
--- a/bundled/tool/lsp_jsonrpc.py
+++ b/bundled/tool/lsp_jsonrpc.py
@@ -181,7 +181,8 @@ class ProcessManager:
                     del self._processes[workspace]
                     rpc = self._rpc.pop(workspace)
                     rpc.close()
-                except:  # pylint: disable=bare-except
+                except KeyError:
+                    # KeyError is sufficient because the process is already dead
                     pass
 
         self._thread_pool.submit(_monitor_process)


### PR DESCRIPTION
{"body": "## Summary\n\nReplaces the bare `except:` clause in `ProcessManager._monitor_process` (the background thread that waits for a workspace's tool subprocess to exit and then cleans up the registry entries) with a `KeyError`-only handler.\n\n## Rationale\n\nThe only operations in the `try` block are:\n\n- `del self._processes[workspace]` — raises `KeyError` if the workspace key has already been removed by `stop_process` or another monitor\n- `self._rpc.pop(workspace)` — raises `KeyError` for the same reason\n- `rpc.close()` — internally wraps every close call in `contextlib.suppress(Exception)`, so it cannot raise\n\nNothing in the block can raise a `BaseException` subclass that we need to silence other than `KeyError`. The original bare `except:` was a `try/except`-with-no-purpose: a `SystemExit` or `KeyboardInterrupt` raised here (extremely unlikely from a `del` / `pop` / `close` call, but conceptually possible if some CPython implementation changed) would have been silently swallowed, which is the wrong default for a thread-pool callback.\n\n## Test plan\n\n- `python -m py_compile bundled/tool/lsp_jsonrpc.py` passes\n- Lint: `pylint bundled/tool/lsp_jsonrpc.py` shows no new warnings\n- Manually traceable: each line in the `try` block has a documented exception type in the Python data model, and `KeyError` covers all of them\n"}
