### PR TITLE
Experiment: integrate shared package as a git submodule

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Build VSIX
         uses: ./.github/actions/build-vsix
@@ -31,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Lint
         uses: ./.github/actions/lint
@@ -54,6 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       # Install bundled libs using env.PYTHON_VERSION even though you test it on other versions.
@@ -106,6 +111,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       - name: Install Node

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Build VSIX
         uses: ./.github/actions/build-vsix
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Lint
         uses: ./.github/actions/lint
@@ -62,6 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       # Install bundled libs using env.PYTHON_VERSION even though you test it on other versions.
@@ -115,6 +120,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       - name: Install Node

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -1,4 +1,4 @@
-name: Shared Package Release Handler
+name: Shared Package Submodule Sync
 
 on:
   repository_dispatch:
@@ -9,32 +9,22 @@ permissions:
   issues: write
 
 concurrency:
-  group: 'shared-package-release-${{ github.event.client_payload.release_tag }}'
+  group: 'shared-package-submodule-${{ github.event.client_payload.release_tag }}'
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: 24.17.0
-  # Match the Python version documented in requirements.in so the regenerated
-  # lockfile stays valid across the supported Python range.
-  PYTHON_VERSION: '3.10'
+  SUBMODULE_PATH: external/vscode-common-python-lsp
 
 jobs:
-  update-shared-packages:
-    name: Update shared packages
+  update-submodule:
+    name: Update shared package submodule
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Install Node
-        uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Validate dispatch payload
         env:
@@ -50,15 +40,6 @@ jobs:
             exit 1
           fi
 
-      - name: Normalize release tag
-        id: release_version
-        env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
-        run: |
-          set -euo pipefail
-          VERSION="${RELEASE_TAG#v}"
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Create branch for this release
         env:
           RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
@@ -69,46 +50,28 @@ jobs:
           # Fetch any pre-existing remote branch so --force-with-lease has a ref.
           git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
           git checkout -B "$BRANCH" origin/main
+          # Re-sync the submodule to whatever the freshly checked-out main records.
+          git submodule update --init --recursive "${SUBMODULE_PATH}"
 
-      - name: Update npm dependency
+      - name: Move submodule to the released commit
         env:
-          NPM_DEP: ${{ github.event.client_payload.npm_dependency }}
-          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
         run: |
           set -euo pipefail
-          if [ -z "${NPM_DEP}" ]; then
-            echo 'No npm dependency in payload; skipping.'
-            exit 0
+          cd "${SUBMODULE_PATH}"
+          git fetch --tags --force origin
+          STRIPPED="${RELEASE_TAG#v}"
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null; then
+            TARGET="refs/tags/${RELEASE_TAG}"
+          elif git rev-parse -q --verify "refs/tags/v${STRIPPED}^{commit}" >/dev/null; then
+            TARGET="refs/tags/v${STRIPPED}"
+          else
+            echo "Release tag '${RELEASE_TAG}' not found upstream; falling back to origin/main." >&2
+            git fetch origin main
+            TARGET="origin/main"
           fi
-          npm install "${NPM_DEP}@${RELEASE_VERSION}"
-
-      - name: Update pip dependency
-        env:
-          PIP_DEP: ${{ github.event.client_payload.pip_dependency }}
-          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
-        run: |
-          set -euo pipefail
-          if [ -z "${PIP_DEP}" ]; then
-            echo 'No pip dependency in payload; skipping.'
-            exit 0
-          fi
-          if [ ! -f requirements.in ]; then
-            echo 'No requirements.in found; skipping.'
-            exit 0
-          fi
-          python -m pip install --upgrade uv
-          # Rewrite the pin (case-insensitive) for the shared package only.
-          sed -i -E "s/^${PIP_DEP}([<>=!~].*)?\$/${PIP_DEP}==${RELEASE_VERSION}/I" requirements.in
-          if ! grep -iEq "^${PIP_DEP}==${RELEASE_VERSION}([[:space:];].*)?\$" requirements.in; then
-            echo "Failed to pin ${PIP_DEP}==${RELEASE_VERSION} in requirements.in." >&2
-            exit 1
-          fi
-          # Scope the re-resolve to the shared package and pin to the documented
-          # Python version so unrelated deps and version markers are preserved.
-          uv pip compile --generate-hashes \
-            --upgrade-package "${PIP_DEP}" \
-            --python-version "${PYTHON_VERSION}" \
-            -o requirements.txt requirements.in
+          echo "Checking out submodule at ${TARGET}."
+          git checkout --detach "${TARGET}"
 
       - name: Push branch and open tracking issue if changed
         env:
@@ -120,18 +83,19 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          if git diff --quiet; then
-            echo 'No changes detected.'
+          # Only the submodule gitlink should have moved.
+          if git diff --quiet -- "${SUBMODULE_PATH}"; then
+            echo 'Submodule already at the released commit; nothing to do.'
             exit 0
           fi
           BRANCH="shared-package-v${RELEASE_TAG#v}"
-          git add -A
-          git commit -m "Upgrade shared package to ${RELEASE_TAG}"
+          git add "${SUBMODULE_PATH}"
+          git commit -m "Update shared package submodule to ${RELEASE_TAG}"
           git push --force-with-lease --set-upstream origin "$BRANCH"
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
-          TITLE="[Shared Package] Open PR to upgrade to ${RELEASE_TAG}"
+          TITLE="[Shared Package] Open PR to update submodule to ${RELEASE_TAG}"
           {
-            echo "### Shared package upgrade ready"
+            echo "### Shared package submodule update ready"
             echo ''
             echo "Branch \`${BRANCH}\` has been pushed."
             echo ''
@@ -141,7 +105,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           BODY_FILE="$(mktemp)"
           cat > "$BODY_FILE" <<EOF
-          Branch \`${BRANCH}\` has been pushed with the shared package upgrade to ${RELEASE_TAG}.
+          Branch \`${BRANCH}\` has been pushed, moving the \`${SUBMODULE_PATH}\` submodule to ${RELEASE_TAG}.
 
           Organization settings prevent this workflow from opening pull requests automatically. Please open the PR manually:
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/vscode-common-python-lsp"]
+	path = external/vscode-common-python-lsp
+	url = https://github.com/microsoft/vscode-common-python-lsp.git

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 out/**
 node_modules/**
+external/**
 src/**
 .gitignore
 .yarnrc

--- a/build/azure-devdiv-pipeline.pre-release.yml
+++ b/build/azure-devdiv-pipeline.pre-release.yml
@@ -42,6 +42,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -37,6 +37,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -48,6 +48,8 @@ extends:
           architecture: 'x64'
         displayName: Select Python version
 
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -45,6 +45,8 @@ extends:
           architecture: 'x64'
         displayName: Select Python version
 
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.validation.yml
+++ b/build/azure-pipeline.validation.yml
@@ -32,6 +32,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,13 +112,15 @@ def install_bundled_libs(session):
     """Installs the libraries that will be bundled with the extension."""
     session.install("wheel")
     _install_bundle(session)
+    # Source the shared Python library from the git submodule instead of the
+    # published package so the bundled copy matches the pinned submodule commit.
     session.install(
         "-t",
         "./bundled/libs",
         "--no-cache-dir",
         "--no-deps",
         "--upgrade",
-        "vscode-common-python-lsp==0.6.0",
+        "./external/vscode-common-python-lsp/python",
     )
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2026.7.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "^0.7.0",
+                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
                 "@vscode/python-extension": "^1.0.5",
                 "dotenv": "^17.4.0",
                 "fs-extra": "^11.3.4",
@@ -45,6 +45,652 @@
             "engines": {
                 "vscode": "^1.82.0"
             }
+        },
+        "external/vscode-common-python-lsp/typescript": {
+            "name": "@vscode/common-python-lsp",
+            "version": "0.8.0",
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+                "@vscode/python-extension": "^1.0.6",
+                "dotenv": "^17.4.1",
+                "fs-extra": "^11.3.4",
+                "semver": "^7.7.4",
+                "vscode-languageclient": "^8.1.0"
+            },
+            "devDependencies": {
+                "@types/chai": "^5.2.3",
+                "@types/fs-extra": "^11.0.4",
+                "@types/mocha": "^10.0.10",
+                "@types/node": "22.x",
+                "@types/semver": "^7.7.1",
+                "@types/sinon": "^21.0.0",
+                "@types/vscode": "^1.74.0",
+                "@typescript-eslint/eslint-plugin": "^7.18.0",
+                "@typescript-eslint/parser": "^7.18.0",
+                "chai": "^6.2.2",
+                "eslint": "^8.57.1",
+                "mocha": "^11.7.5",
+                "prettier": "^3.8.1",
+                "sinon": "^22.0.0",
+                "typescript": "^6.0.3"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "vscode": "^1.74.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@eslint/eslintrc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.12.4",
+                "debug": "^4.3.2",
+                "espree": "^9.6.0",
+                "globals": "^13.19.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.0",
+                "minimatch": "^3.1.2",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@eslint/js": {
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@sinonjs/samsam": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
+            "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "type-detect": "^4.1.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+            "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "7.18.0",
+                "@typescript-eslint/type-utils": "7.18.0",
+                "@typescript-eslint/utils": "7.18.0",
+                "@typescript-eslint/visitor-keys": "7.18.0",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.3.1",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^7.0.0",
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/parser": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+            "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "7.18.0",
+                "@typescript-eslint/types": "7.18.0",
+                "@typescript-eslint/typescript-estree": "7.18.0",
+                "@typescript-eslint/visitor-keys": "7.18.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/scope-manager": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+            "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "7.18.0",
+                "@typescript-eslint/visitor-keys": "7.18.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/type-utils": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+            "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "7.18.0",
+                "@typescript-eslint/utils": "7.18.0",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/types": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+            "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+            "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@typescript-eslint/types": "7.18.0",
+                "@typescript-eslint/visitor-keys": "7.18.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/utils": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+            "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "7.18.0",
+                "@typescript-eslint/types": "7.18.0",
+                "@typescript-eslint/typescript-estree": "7.18.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+            "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "7.18.0",
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/diff": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+            "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/eslint": {
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+            "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.1",
+                "@humanwhocodes/config-array": "^0.13.0",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
+                "debug": "^4.3.2",
+                "doctrine": "^3.0.0",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
+                "esquery": "^1.4.2",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^6.0.1",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "globals": "^13.19.0",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "is-path-inside": "^3.0.3",
+                "js-yaml": "^4.1.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.4.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.2",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3",
+                "strip-ansi": "^6.0.1",
+                "text-table": "^0.2.0"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/eslint-scope": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/espree": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.9.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/file-entry-cache": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flat-cache": "^3.0.4"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/flat-cache": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.3",
+                "rimraf": "^3.0.2"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/globals": {
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/sinon": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
+            "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "^15.4.0",
+                "@sinonjs/samsam": "^10.0.2",
+                "diff": "^9.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/sinon"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/ts-api-utils": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.2.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/type-detect": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "license": "MIT",
+            "dependencies": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "engines": {
+                "vscode": "^1.67.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
+            "license": "MIT"
         },
         "node_modules/@azu/format-text": {
             "version": "1.0.2",
@@ -441,6 +1087,22 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@humanwhocodes/config-array": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+            "deprecated": "Use @eslint/config-array instead",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanwhocodes/object-schema": "^2.0.3",
+                "debug": "^4.3.1",
+                "minimatch": "^3.0.5"
+            },
+            "engines": {
+                "node": ">=10.10.0"
+            }
+        },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -454,6 +1116,14 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
             }
+        },
+        "node_modules/@humanwhocodes/object-schema": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+            "deprecated": "Use @eslint/object-schema instead",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.4.3",
@@ -885,10 +1555,11 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-            "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1"
             }
@@ -1003,6 +1674,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/eslint": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -1097,6 +1775,13 @@
             "version": "2.1.7",
             "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1395,83 +2080,16 @@
                 "node": ">=20.0.0"
             }
         },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+            "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.7.0.tgz",
-            "integrity": "sha512-sBWIZqgJLeWWCEWf+Bd5SQSPaV/q9zoCbjNC2xCWZGW0bUts6hKfkse29MYTL/EU29bhi3Aa16l8RTAUIplYEg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
-                "@vscode/python-extension": "^1.0.6",
-                "dotenv": "^17.4.1",
-                "fs-extra": "^11.3.4",
-                "semver": "^7.7.4",
-                "vscode-languageclient": "^8.1.0"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "vscode": "^1.74.0"
-            }
-        },
-        "node_modules/@vscode/common-python-lsp/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@vscode/common-python-lsp/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@vscode/common-python-lsp/node_modules/vscode-jsonrpc": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageclient": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
-            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
-            "license": "MIT",
-            "dependencies": {
-                "minimatch": "^5.1.0",
-                "semver": "^7.3.7",
-                "vscode-languageserver-protocol": "3.17.3"
-            },
-            "engines": {
-                "vscode": "^1.67.0"
-            }
-        },
-        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-jsonrpc": "8.1.0",
-                "vscode-languageserver-types": "3.17.3"
-            }
-        },
-        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageserver-types": {
-            "version": "3.17.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
-            "license": "MIT"
+            "resolved": "external/vscode-common-python-lsp/typescript",
+            "link": true
         },
         "node_modules/@vscode/python-environments": {
             "version": "1.0.0",
@@ -2101,6 +2719,16 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
+        },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/assertion-error": {
             "version": "1.1.0",
@@ -2913,6 +3541,42 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dir-glob/node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "esutils": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/dom-serializer": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
@@ -3670,6 +4334,13 @@
                 "node": ">=14.14"
             }
         },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3956,6 +4627,13 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4188,6 +4866,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "node_modules/inherits": {
@@ -5274,7 +5964,6 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
-            "optional": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -5602,6 +6291,16 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
@@ -6149,6 +6848,45 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/run-applescript": {
@@ -7670,8 +8408,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "node_modules/wsl-utils": {
             "version": "0.1.0",
@@ -8066,10 +8803,27 @@
                 }
             }
         },
+        "@humanwhocodes/config-array": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+            "dev": true,
+            "requires": {
+                "@humanwhocodes/object-schema": "^2.0.3",
+                "debug": "^4.3.1",
+                "minimatch": "^3.0.5"
+            }
+        },
         "@humanwhocodes/module-importer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true
+        },
+        "@humanwhocodes/object-schema": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "dev": true
         },
         "@humanwhocodes/retry": {
@@ -8382,9 +9136,9 @@
             }
         },
         "@sinonjs/fake-timers": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-            "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^3.0.1"
@@ -8490,6 +9244,12 @@
             "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
             "dev": true
         },
+        "@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true
+        },
         "@types/eslint": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -8575,6 +9335,12 @@
             "version": "2.1.7",
             "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+            "dev": true
+        },
+        "@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true
         },
         "@types/sinon": {
@@ -8759,34 +9525,381 @@
                 "tslib": "^2.6.2"
             }
         },
+        "@ungap/structured-clone": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+            "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+            "dev": true
+        },
         "@vscode/common-python-lsp": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.7.0.tgz",
-            "integrity": "sha512-sBWIZqgJLeWWCEWf+Bd5SQSPaV/q9zoCbjNC2xCWZGW0bUts6hKfkse29MYTL/EU29bhi3Aa16l8RTAUIplYEg==",
+            "version": "file:external/vscode-common-python-lsp/typescript",
             "requires": {
+                "@types/chai": "^5.2.3",
+                "@types/fs-extra": "^11.0.4",
+                "@types/mocha": "^10.0.10",
+                "@types/node": "22.x",
+                "@types/semver": "^7.7.1",
+                "@types/sinon": "^21.0.0",
+                "@types/vscode": "^1.74.0",
+                "@typescript-eslint/eslint-plugin": "^7.18.0",
+                "@typescript-eslint/parser": "^7.18.0",
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/python-extension": "^1.0.6",
+                "chai": "^6.2.2",
                 "dotenv": "^17.4.1",
+                "eslint": "^8.57.1",
                 "fs-extra": "^11.3.4",
+                "mocha": "^11.7.5",
+                "prettier": "^3.8.1",
                 "semver": "^7.7.4",
+                "sinon": "^22.0.0",
+                "typescript": "^6.0.3",
                 "vscode-languageclient": "^8.1.0"
             },
             "dependencies": {
+                "@eslint/eslintrc": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+                    "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.12.4",
+                        "debug": "^4.3.2",
+                        "espree": "^9.6.0",
+                        "globals": "^13.19.0",
+                        "ignore": "^5.2.0",
+                        "import-fresh": "^3.2.1",
+                        "js-yaml": "^4.1.0",
+                        "minimatch": "^3.1.2",
+                        "strip-json-comments": "^3.1.1"
+                    }
+                },
+                "@eslint/js": {
+                    "version": "8.57.1",
+                    "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+                    "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+                    "dev": true
+                },
+                "@sinonjs/samsam": {
+                    "version": "10.0.2",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
+                    "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^3.0.1",
+                        "type-detect": "^4.1.0"
+                    }
+                },
+                "@types/chai": {
+                    "version": "5.2.3",
+                    "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+                    "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/deep-eql": "*",
+                        "assertion-error": "^2.0.1"
+                    }
+                },
+                "@typescript-eslint/eslint-plugin": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+                    "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/regexpp": "^4.10.0",
+                        "@typescript-eslint/scope-manager": "7.18.0",
+                        "@typescript-eslint/type-utils": "7.18.0",
+                        "@typescript-eslint/utils": "7.18.0",
+                        "@typescript-eslint/visitor-keys": "7.18.0",
+                        "graphemer": "^1.4.0",
+                        "ignore": "^5.3.1",
+                        "natural-compare": "^1.4.0",
+                        "ts-api-utils": "^1.3.0"
+                    }
+                },
+                "@typescript-eslint/parser": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+                    "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "@typescript-eslint/scope-manager": "7.18.0",
+                        "@typescript-eslint/types": "7.18.0",
+                        "@typescript-eslint/typescript-estree": "7.18.0",
+                        "@typescript-eslint/visitor-keys": "7.18.0",
+                        "debug": "^4.3.4"
+                    }
+                },
+                "@typescript-eslint/scope-manager": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+                    "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "7.18.0",
+                        "@typescript-eslint/visitor-keys": "7.18.0"
+                    }
+                },
+                "@typescript-eslint/type-utils": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+                    "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/typescript-estree": "7.18.0",
+                        "@typescript-eslint/utils": "7.18.0",
+                        "debug": "^4.3.4",
+                        "ts-api-utils": "^1.3.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+                    "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+                    "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "7.18.0",
+                        "@typescript-eslint/visitor-keys": "7.18.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "minimatch": "^9.0.4",
+                        "semver": "^7.6.0",
+                        "ts-api-utils": "^1.3.0"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "9.0.9",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+                            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^2.0.2"
+                            }
+                        }
+                    }
+                },
+                "@typescript-eslint/utils": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+                    "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/eslint-utils": "^4.4.0",
+                        "@typescript-eslint/scope-manager": "7.18.0",
+                        "@typescript-eslint/types": "7.18.0",
+                        "@typescript-eslint/typescript-estree": "7.18.0"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "7.18.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+                    "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "7.18.0",
+                        "eslint-visitor-keys": "^3.4.3"
+                    }
+                },
+                "assertion-error": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+                    "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+                    "dev": true
+                },
                 "brace-expansion": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-                    "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+                    "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
                     "requires": {
                         "balanced-match": "^1.0.0"
                     }
                 },
-                "minimatch": {
-                    "version": "5.1.9",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-                    "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+                "chai": {
+                    "version": "6.2.2",
+                    "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+                    "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+                    "dev": true
+                },
+                "diff": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+                    "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+                    "dev": true
+                },
+                "eslint": {
+                    "version": "8.57.1",
+                    "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+                    "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+                    "dev": true,
+                    "peer": true,
                     "requires": {
-                        "brace-expansion": "^2.0.1"
+                        "@eslint-community/eslint-utils": "^4.2.0",
+                        "@eslint-community/regexpp": "^4.6.1",
+                        "@eslint/eslintrc": "^2.1.4",
+                        "@eslint/js": "8.57.1",
+                        "@humanwhocodes/config-array": "^0.13.0",
+                        "@humanwhocodes/module-importer": "^1.0.1",
+                        "@nodelib/fs.walk": "^1.2.8",
+                        "@ungap/structured-clone": "^1.2.0",
+                        "ajv": "^6.12.4",
+                        "chalk": "^4.0.0",
+                        "cross-spawn": "^7.0.2",
+                        "debug": "^4.3.2",
+                        "doctrine": "^3.0.0",
+                        "escape-string-regexp": "^4.0.0",
+                        "eslint-scope": "^7.2.2",
+                        "eslint-visitor-keys": "^3.4.3",
+                        "espree": "^9.6.1",
+                        "esquery": "^1.4.2",
+                        "esutils": "^2.0.2",
+                        "fast-deep-equal": "^3.1.3",
+                        "file-entry-cache": "^6.0.1",
+                        "find-up": "^5.0.0",
+                        "glob-parent": "^6.0.2",
+                        "globals": "^13.19.0",
+                        "graphemer": "^1.4.0",
+                        "ignore": "^5.2.0",
+                        "imurmurhash": "^0.1.4",
+                        "is-glob": "^4.0.0",
+                        "is-path-inside": "^3.0.3",
+                        "js-yaml": "^4.1.0",
+                        "json-stable-stringify-without-jsonify": "^1.0.1",
+                        "levn": "^0.4.1",
+                        "lodash.merge": "^4.6.2",
+                        "minimatch": "^3.1.2",
+                        "natural-compare": "^1.4.0",
+                        "optionator": "^0.9.3",
+                        "strip-ansi": "^6.0.1",
+                        "text-table": "^0.2.0"
                     }
+                },
+                "eslint-scope": {
+                    "version": "7.2.2",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+                    "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^5.2.0"
+                    }
+                },
+                "espree": {
+                    "version": "9.6.1",
+                    "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+                    "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^8.9.0",
+                        "acorn-jsx": "^5.3.2",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
+                "estraverse": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                    "dev": true
+                },
+                "file-entry-cache": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+                    "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+                    "dev": true,
+                    "requires": {
+                        "flat-cache": "^3.0.4"
+                    }
+                },
+                "flat-cache": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+                    "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+                    "dev": true,
+                    "requires": {
+                        "flatted": "^3.2.9",
+                        "keyv": "^4.5.3",
+                        "rimraf": "^3.0.2"
+                    }
+                },
+                "globals": {
+                    "version": "13.24.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+                    "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.20.2"
+                    }
+                },
+                "globby": {
+                    "version": "11.1.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+                    "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.2.9",
+                        "ignore": "^5.2.0",
+                        "merge2": "^1.4.1",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "5.3.2",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+                    "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+                    "dev": true
+                },
+                "sinon": {
+                    "version": "22.0.0",
+                    "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
+                    "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^3.0.1",
+                        "@sinonjs/fake-timers": "^15.4.0",
+                        "@sinonjs/samsam": "^10.0.2",
+                        "diff": "^9.0.0"
+                    }
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "ts-api-utils": {
+                    "version": "1.4.3",
+                    "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+                    "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+                    "dev": true,
+                    "requires": {}
+                },
+                "type-detect": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+                    "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+                    "dev": true
+                },
+                "type-fest": {
+                    "version": "0.20.2",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+                    "dev": true
+                },
+                "typescript": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+                    "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+                    "dev": true,
+                    "peer": true
                 },
                 "vscode-jsonrpc": {
                     "version": "8.1.0",
@@ -8801,6 +9914,16 @@
                         "minimatch": "^5.1.0",
                         "semver": "^7.3.7",
                         "vscode-languageserver-protocol": "3.17.3"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "5.1.9",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+                            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+                            "requires": {
+                                "brace-expansion": "^2.0.1"
+                            }
+                        }
                     }
                 },
                 "vscode-languageserver-protocol": {
@@ -9264,6 +10387,12 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true
         },
         "assertion-error": {
@@ -9807,6 +10936,32 @@
             "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
             "dev": true
         },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                }
+            }
+        },
+        "doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
         "dom-serializer": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
@@ -10329,6 +11484,12 @@
                 "universalify": "^2.0.0"
             }
         },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
         "function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -10532,6 +11693,12 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
+        "graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+            "dev": true
+        },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -10675,6 +11842,16 @@
             "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
             "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
             "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
         },
         "inherits": {
             "version": "2.0.4",
@@ -11478,7 +12655,6 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -11697,6 +12873,12 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true
         },
         "path-key": {
@@ -12077,6 +13259,31 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true
+        },
+        "rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.1.1",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
         },
         "run-applescript": {
             "version": "7.0.0",
@@ -13095,8 +14302,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "wsl-utils": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "main": "./dist/extension.js",
     "l10n": "./l10n",
     "scripts": {
+        "postinstall": "npm --prefix external/vscode-common-python-lsp/typescript run build",
         "compile": "webpack",
         "compile-tests": "tsc -p . --outDir out",
         "format-check": "prettier --check \"src/**/*.ts\" \"build/**/*.yml\" \".github/**/*.yml\"",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "^0.7.0",
+        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
         "@vscode/python-extension": "^1.0.5",
         "dotenv": "^17.4.0",
         "fs-extra": "^11.3.4",

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,3 @@
 pygls
 packaging
 black
-vscode-common-python-lsp==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -185,7 +185,3 @@ typing-extensions==4.15.0 \
     #   black
     #   cattrs
     #   exceptiongroup
-vscode-common-python-lsp==0.6.0 \
-    --hash=sha256:499bf066372ed86a62f140a668a4b0f72328cdf8d08057df45892fc1c5b627f6 \
-    --hash=sha256:6892a401311217f501d9b2f86a82a9629c89d565082330adb77bf8cddf634a72
-    # via -r ./requirements.in

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "lib": ["ES2020"],
         "sourceMap": true,
         "rootDir": "src",
+        "skipLibCheck": true,
         "strict": true /* enable all strict type-checking options */
         /* Additional Checks */
         // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,7 @@
         // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
         // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
         // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-    }
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "external", "out", "dist", ".vscode-test"]
 }


### PR DESCRIPTION
**Experiment:** integrate the shared package as a git submodule instead of an external published dependency.

This PR targets `shared-package-sync` so the diff isolates the submodule conversion on top of that branch.

### Changes
- Add `external/vscode-common-python-lsp` as a git submodule, pinned to `v0.8.0`.
- `package.json`: `@vscode/common-python-lsp` -> `file:external/vscode-common-python-lsp/typescript`.
- `noxfile.py`: bundle the Python lib from `./external/vscode-common-python-lsp/python` (`--no-deps`).
- `requirements.in` / `requirements.txt`: drop the `vscode-common-python-lsp` pin and hash block (now sourced from the submodule).
- Replace `shared-package-release.yml` (version bump) with `shared-package-submodule-sync.yml` (bumps the submodule commit to the released tag, pushes a branch, opens a tracking issue with a manual-PR link).

### Notes / caveats
- CI must check out submodules (`submodules: recursive`) and build the TS submodule (`dist/`) before packaging — the `file:` install does not run a `prepare` build.
- `--generate-hashes` cannot hash a local path, so the shared Python lib is intentionally out of the hashed lockfile and installed via the submodule.