### PR TITLE
Fail label check when no-merge is present

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -20,3 +20,9 @@ jobs:
           mode: minimum
           count: 1
           labels: 'bug, debt, feature-request, no-changelog, dependencies'
+      - name: 'PR is mergeable'
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: maximum
+          count: 0
+          labels: 'no-merge'


### PR DESCRIPTION
## Summary

- fail the PR label check when the `no-merge` label is present
- preserve the existing required impact-label validation

## Validation

- parsed the workflow as YAML
- verified Prettier formatting