### PR TITLE
Use Python 3.10 in Azure validation pipeline

### DIFF
--- a/build/azure-pipeline.validation.yml
+++ b/build/azure-pipeline.validation.yml
@@ -25,8 +25,6 @@ variables:
     value: VSCode-black-formatter
   - name: VsixName
     value: black-formatter.vsix
-  - name: PythonVersion
-    value: '3.10'
   - name: AZURE_ARTIFACTS_FEED
     value: 'https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/'
 
@@ -36,10 +34,6 @@ parameters:
     default:
       - script: git submodule update --init --recursive
         displayName: Checkout submodules
-      - task: UsePythonVersion@0
-        displayName: Use Python $(PythonVersion)
-        inputs:
-          versionSpec: $(PythonVersion)
       - script: npm ci
         displayName: Install NPM dependencies
 
@@ -80,3 +74,4 @@ extends:
               isPreRelease: false
               standardizedVersioning: true
               customNPMRegistry: $(AZURE_ARTIFACTS_FEED)
+              pythonVersion: '3.10'

--- a/build/azure-pipeline.validation.yml
+++ b/build/azure-pipeline.validation.yml
@@ -25,6 +25,8 @@ variables:
     value: VSCode-black-formatter
   - name: VsixName
     value: black-formatter.vsix
+  - name: PythonVersion
+    value: '3.10'
   - name: AZURE_ARTIFACTS_FEED
     value: 'https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/'
 
@@ -34,6 +36,10 @@ parameters:
     default:
       - script: git submodule update --init --recursive
         displayName: Checkout submodules
+      - task: UsePythonVersion@0
+        displayName: Use Python $(PythonVersion)
+        inputs:
+          versionSpec: $(PythonVersion)
       - script: npm ci
         displayName: Install NPM dependencies
 


### PR DESCRIPTION
## Summary

- explicitly select Python 3.10 in the Azure validation pipeline
- avoid the external job template's Python 3.9 default before installing Nox and bundled dependencies
- replace the previous PR to retrigger Azure validation

## Validation

- parsed the updated pipeline as YAML and verified the Python task ordering
- verified Prettier formatting