### PR TITLE
Remove dependencies provided by shared package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,10 +35,30 @@ updates:
     directories:
       - '/'
       - '/src/test/python_tests'
+    # Multi-ecosystem groups only support positive patterns. Keep Black
+    # unmatched so its updates remain standalone.
     patterns:
-      - '*'
-    exclude-patterns:
-      - 'black'
+      - 'attrs'
+      - 'cattrs'
+      - 'click'
+      - 'colorama'
+      - 'exceptiongroup'
+      - 'iniconfig'
+      - 'lsprotocol'
+      - 'mypy-extensions'
+      - 'packaging'
+      - 'pathspec'
+      - 'platformdirs'
+      - 'pluggy'
+      - 'pygls'
+      - 'pygments'
+      - 'pyhamcrest'
+      - 'pytest'
+      - 'python-jsonrpc-server'
+      - 'pytokens'
+      - 'tomli'
+      - 'typing-extensions'
+      - 'ujson'
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: 'weekly'
-    exclude-patterns:
-      - 'black'
     labels:
       - 'dependencies'
       - 'debt'
@@ -39,6 +37,8 @@ updates:
       - '/src/test/python_tests'
     patterns:
       - '*'
+    exclude-patterns:
+      - 'black'
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'debt'
@@ -22,7 +23,6 @@ updates:
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
@@ -62,7 +62,6 @@ updates:
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
 
   # The shared package submodule is updated daily in a standalone PR.
   - package-ecosystem: 'gitsubmodule'
@@ -86,4 +85,3 @@ updates:
     patterns:
       - '*'
     multi-ecosystem-group: 'dependencies'
-    open-pull-requests-limit: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
             "license": "MIT",
             "dependencies": {
                 "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
-                "@vscode/python-extension": "^1.0.5",
-                "dotenv": "^17.4.0",
-                "fs-extra": "^11.3.5",
                 "vscode-languageclient": "^9.0.1"
             },
             "devDependencies": {
@@ -27,11 +24,11 @@
                 "@types/vscode": "^1.74.0",
                 "@typescript-eslint/eslint-plugin": "^8.62.0",
                 "@typescript-eslint/parser": "^8.62.0",
-                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/test-electron": "^2.5.2",
                 "@vscode/vsce": "^3.9.2",
                 "chai": "^6.2.2",
                 "eslint": "^10.0.0",
+                "fs-extra": "^11.3.5",
                 "glob": "^13.0.6",
                 "mocha": "^11.7.6",
                 "prettier": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -188,9 +188,6 @@
     },
     "dependencies": {
         "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
-        "@vscode/python-extension": "^1.0.5",
-        "dotenv": "^17.4.0",
-        "fs-extra": "^11.3.5",
         "vscode-languageclient": "^9.0.1"
     },
     "devDependencies": {
@@ -204,11 +201,11 @@
         "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^8.62.0",
         "@typescript-eslint/parser": "^8.62.0",
-        "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.9.2",
         "chai": "^6.2.2",
         "eslint": "^10.0.0",
+        "fs-extra": "^11.3.5",
         "glob": "^13.0.6",
         "mocha": "^11.7.6",
         "prettier": "^3.8.4",


### PR DESCRIPTION
## Summary  - remove extension-level npm dependencies already provided by `@vscode/common-python-lsp`  - keep dependencies still imported by extension-owned source or tests - remove stale dependency-update exclusions where the shared package now owns the dependency   ## Dependabot configuration  - use supported positive `patterns` to group all currently locked non-tool Python dependencies - leave the primary tool unmatched so its updates remain standalone 
- set the pull request limit on the multi-ecosystem group, as required by Dependabot's schema